### PR TITLE
Evaluate track item keyframes during rendering

### DIFF
--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -527,6 +527,16 @@ namespace PressPlay.Models
         [JsonIgnore]
         public List<Keyframe> OpacityKeyframes => Keyframes[nameof(Opacity)];
 
+        public void EvaluateKeyframes(int frame)
+        {
+            TranslateX = GetAnimated(nameof(TranslateX), frame);
+            TranslateY = GetAnimated(nameof(TranslateY), frame);
+            Rotation = GetAnimated(nameof(Rotation), frame);
+            ScaleX = GetAnimated(nameof(ScaleX), frame);
+            ScaleY = GetAnimated(nameof(ScaleY), frame);
+            Opacity = GetAnimated(nameof(Opacity), frame);
+        }
+
         public double GetAnimated(string property, int frame)
         {
             if (!Keyframes.TryGetValue(property, out var frames) || frames.Count == 0)

--- a/PressPlay/Services/PlaybackService.cs
+++ b/PressPlay/Services/PlaybackService.cs
@@ -372,7 +372,13 @@ namespace PressPlay.Services
 
                     // 5) Draw each with its fade
                     foreach (var item in activeItems)
+                    {
+                        // Update transform properties from keyframes before drawing
+                        if (item is TrackItem ti)
+                            ti.EvaluateKeyframes(idx);
+
                         DrawItemWithFade(item, idx, width, height, dc);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Evaluate transform keyframes for each track item before drawing
- Add `EvaluateKeyframes` helper to track items for interpolation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f652136883218b8231ecf84a7315