### PR TITLE
Add keyframe strips and property editors

### DIFF
--- a/PressPlay/Converters/KeyframePositionConverter.cs
+++ b/PressPlay/Converters/KeyframePositionConverter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+using PressPlay.Helpers;
+
+namespace PressPlay.Converters
+{
+    public class KeyframePositionConverter : MarkupExtension, IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 3)
+                return 0.0;
+
+            if (values[0] is int frame &&
+                values[1] is int startFrame &&
+                values[2] is int zoom)
+            {
+                int diff = frame - startFrame;
+                return Constants.FramesToPixels(diff, zoom);
+            }
+            return 0.0;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -173,6 +173,188 @@
             </Grid.Style>
         </Grid>
 
+        <!-- Property editors shown when item is selected -->
+        <StackPanel x:Name="PropertyEditors"
+                    Orientation="Vertical"
+                    Panel.ZIndex="3"
+                    Width="120"
+                    Margin="2"
+                    Background="#80000000"
+                    Visibility="{Binding IsSelected, Converter={converters:BoolToVisibilityConverter}}">
+            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged" />
+            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged" />
+            <Slider Minimum="0" Maximum="360" Value="{Binding Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged" />
+            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged" />
+            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged" />
+            <Slider Minimum="0" Maximum="1" Value="{Binding Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged" />
+        </StackPanel>
+
+        <!-- Keyframe strips -->
+        <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000">
+            <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl x:Name="translateYStrip" Height="10" Tag="TranslateY" ItemsSource="{Binding TranslateYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl x:Name="rotationStrip" Height="10" Tag="Rotation" ItemsSource="{Binding RotationKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl x:Name="scaleXStrip" Height="10" Tag="ScaleX" ItemsSource="{Binding ScaleXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl x:Name="scaleYStrip" Height="10" Tag="ScaleY" ItemsSource="{Binding ScaleYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl x:Name="opacityStrip" Height="10" Tag="Opacity" ItemsSource="{Binding OpacityKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left">
+                            <Setter.Value>
+                                <MultiBinding Converter="{converters:KeyframePositionConverter}">
+                                    <Binding Path="Frame"/>
+                                    <Binding Path="DataContext.Position.TotalFrames" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                    <Binding Path="(local:TimelineControl.Project).TimelineZoom" RelativeSource="{RelativeSource AncestorType=local:TimelineControl}"/>
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                                   MouseMove="Keyframe_MouseMove"
+                                   MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
         <!-- fade‐in handle -->
         <Polygon Opacity="0.5" HorizontalAlignment="Left"  Panel.ZIndex="1">
             <Polygon.Style>

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using System.Windows.Media;
 using PressPlay.Helpers;
 using PressPlay.Models;
 using PressPlay.Utilities;
@@ -18,6 +19,8 @@ namespace PressPlay.Timeline
     {
         private TimelineControl _timelineControl;
         private Point _startPoint;
+        private Keyframe? _draggingKeyframe;
+        private ItemsControl? _draggingStrip;
 
         public TrackItemControl()
         {
@@ -66,6 +69,34 @@ namespace PressPlay.Timeline
                     _timelineControl.Project.RaiseNeedlePositionTimeChanged(
                         _timelineControl.Project.NeedlePositionTime);
                 }
+            }
+        }
+
+        private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (sender is Slider slider && DataContext is TrackItem item)
+            {
+                _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
+                var project = _timelineControl?.Project;
+                if (project == null) return;
+
+                int frame = project.NeedlePositionTime.TotalFrames;
+                string property = slider.Tag as string ?? string.Empty;
+
+                if (!item.Keyframes.TryGetValue(property, out var list))
+                    return;
+
+                var existing = list.FirstOrDefault(k => k.Frame == frame);
+                if (existing != null)
+                {
+                    existing.Value = e.NewValue;
+                }
+                else
+                {
+                    list.Add(new Keyframe { Frame = frame, Value = e.NewValue });
+                }
+
+                RefreshKeyframeStrip(property);
             }
         }
 
@@ -240,6 +271,104 @@ namespace PressPlay.Timeline
                 var offset = PixelCalculator.GetPixels(trackItem.Start.TotalFrames, project.TimelineZoom);
                 img.Margin = new Thickness(-offset, 0, 0, 0);
             }
+        }
+
+        private void KeyframeStrip_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is ItemsControl strip && DataContext is TrackItem item)
+            {
+                _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
+                var project = _timelineControl?.Project;
+                if (project == null) return;
+
+                if (e.OriginalSource is Canvas)
+                {
+                    double x = e.GetPosition(strip).X;
+                    int frame = item.Position.TotalFrames + Constants.PixelsToFrames(x, project.TimelineZoom);
+                    string property = strip.Tag as string ?? string.Empty;
+                    if (!item.Keyframes.TryGetValue(property, out var list)) return;
+                    if (!list.Any(k => k.Frame == frame))
+                    {
+                        double value = item.GetAnimated(property, frame);
+                        list.Add(new Keyframe { Frame = frame, Value = value });
+                        RefreshKeyframeStrip(property);
+                    }
+                }
+            }
+        }
+
+        private void Keyframe_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is Keyframe kf)
+            {
+                _draggingKeyframe = kf;
+                _draggingStrip = GetParentItemsControl(fe);
+                fe.CaptureMouse();
+                e.Handled = true;
+            }
+        }
+
+        private void Keyframe_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (_draggingKeyframe != null && _draggingStrip != null && DataContext is TrackItem item)
+            {
+                _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
+                var project = _timelineControl?.Project;
+                if (project == null) return;
+
+                double x = e.GetPosition(_draggingStrip).X;
+                int frame = item.Position.TotalFrames + Constants.PixelsToFrames(x, project.TimelineZoom);
+                _draggingKeyframe.Frame = frame;
+                RefreshKeyframeStrip(_draggingStrip.Tag as string ?? string.Empty);
+            }
+        }
+
+        private void Keyframe_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement fe)
+                fe.ReleaseMouseCapture();
+            _draggingKeyframe = null;
+            _draggingStrip = null;
+        }
+
+        private void Keyframe_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is Keyframe kf && DataContext is TrackItem item)
+            {
+                var strip = GetParentItemsControl(fe);
+                string property = strip?.Tag as string ?? string.Empty;
+                if (item.Keyframes.TryGetValue(property, out var list))
+                {
+                    list.Remove(kf);
+                    RefreshKeyframeStrip(property);
+                }
+                e.Handled = true;
+            }
+        }
+
+        private ItemsControl? GetParentItemsControl(DependencyObject child)
+        {
+            while (child != null && child is not ItemsControl)
+            {
+                child = VisualTreeHelper.GetParent(child);
+            }
+            return child as ItemsControl;
+        }
+
+        private void RefreshKeyframeStrip(string property)
+        {
+            ItemsControl? strip = property switch
+            {
+                nameof(TrackItem.TranslateX) => translateXStrip,
+                nameof(TrackItem.TranslateY) => translateYStrip,
+                nameof(TrackItem.Rotation) => rotationStrip,
+                nameof(TrackItem.ScaleX) => scaleXStrip,
+                nameof(TrackItem.ScaleY) => scaleYStrip,
+                nameof(TrackItem.Opacity) => opacityStrip,
+                _ => null
+            };
+
+            strip?.Items.Refresh();
         }
     }
 }


### PR DESCRIPTION
## Summary
- display keyframe strips for translate, rotate, scale, and opacity
- provide sliders for editing properties at the current playhead
- add converters and mouse handlers to manage keyframes on the timeline

## Testing
- `dotnet build PressPlay.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f77ea88c8321bfa656ee0209e908