### PR TITLE
Serialize keyframe dictionaries and add regression tests

### DIFF
--- a/PressPlay.Tests/PressPlay.Tests.csproj
+++ b/PressPlay.Tests/PressPlay.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PressPlay\PressPlay.csproj" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+</Project>

--- a/PressPlay.Tests/ProjectSerializationTests.cs
+++ b/PressPlay.Tests/ProjectSerializationTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Nodes;
+using PressPlay.Models;
+using PressPlay.Serialization;
+using Xunit;
+
+namespace PressPlay.Tests;
+
+public class ProjectSerializationTests
+{
+    private static string RemoveKeyframes(string json)
+    {
+        var node = JsonNode.Parse(json)!;
+        var item = node["Tracks"]?[0]?["Items"]?[0] as JsonObject;
+        item?.Remove("Keyframes");
+        return node.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [Fact]
+    public void Deserializing_OldProject_WithoutKeyframes_UsesStaticValues()
+    {
+        var project = new Project { FPS = 25 };
+        var track = new Track { Name = "V1" };
+        var item = new TrackItem
+        {
+            Position = new TimeCode(0, 25),
+            Start = new TimeCode(0, 25),
+            End = new TimeCode(10, 25),
+            OriginalEnd = new TimeCode(10, 25),
+            SourceLength = new TimeCode(10, 25),
+            FileName = "clip.mp4",
+            FilePath = "clip.mp4",
+            FullPath = "clip.mp4",
+            TranslateX = 12.5,
+            TranslateY = -3.0,
+            ScaleX = 1.5,
+            ScaleY = 0.75,
+            Rotation = 45.0,
+            Opacity = 0.8,
+            Volume = 0.9f
+        };
+        track.Items.Add(item);
+        project.Tracks.Add(track);
+
+        var json = ProjectSerializer.SerializeProject(project);
+        json = RemoveKeyframes(json);
+
+        var loaded = ProjectSerializer.DeserializeProject(json);
+        var loadedItem = Assert.IsType<TrackItem>(loaded.Tracks[0].Items[0]);
+
+        Assert.Equal(12.5, loadedItem.TranslateX);
+        Assert.Equal(-3.0, loadedItem.TranslateY);
+        Assert.Equal(1.5, loadedItem.ScaleX);
+        Assert.Equal(0.75, loadedItem.ScaleY);
+        Assert.Equal(45.0, loadedItem.Rotation);
+        Assert.Equal(0.8, loadedItem.Opacity);
+        Assert.Empty(loadedItem.Keyframes[nameof(TrackItem.TranslateX)]);
+
+        loadedItem.EvaluateKeyframes(0);
+        Assert.Equal(12.5, loadedItem.TranslateX);
+    }
+}

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -419,6 +419,26 @@ namespace PressPlay.Serialization
                 }
                 if (root.TryGetProperty("Volume", out var volumeElement))
                     ti.Volume = volumeElement.GetSingle();
+
+                // Keyframe dictionary (optional for backward compatibility)
+                if (root.TryGetProperty("Keyframes", out var kfElement))
+                {
+                    try
+                    {
+                        var dict = JsonSerializer.Deserialize<Dictionary<string, List<Keyframe>>>(kfElement.GetRawText(), options);
+                        if (dict != null)
+                        {
+                            foreach (var kv in dict)
+                            {
+                                ti.Keyframes[kv.Key] = kv.Value ?? new List<Keyframe>();
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to deserialize keyframes: {ex.Message}");
+                    }
+                }
             }
 
             // Special handling for AudioTrackItem
@@ -500,6 +520,10 @@ namespace PressPlay.Serialization
                 writer.WriteNumber("Y", ti.RotationOrigin.Y);
                 writer.WriteEndObject();
                 writer.WriteNumber("Volume", ti.Volume);
+
+                // Serialize keyframe dictionary
+                writer.WritePropertyName("Keyframes");
+                JsonSerializer.Serialize(writer, ti.Keyframes, options);
             }
 
             // Audio-specific properties


### PR DESCRIPTION
## Summary
- Preserve keyframe dictionaries when saving and loading track items
- Handle missing keyframe data for backwards compatibility
- Add test covering deserialization of legacy projects without keyframes

## Testing
- `dotnet test PressPlay.Tests/PressPlay.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f9903c808321b2fe33ffb2b946dc