### PR TITLE
Improve keyframe UI

### DIFF
--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -23,6 +23,26 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
         <converters:SelectedItemFinder x:Key="SelectedItemFinder"/>
         <converters:CurrentBlendModeConverter x:Key="CurrentBlendModeConverter"/>
+        <Style x:Key="KeyframeButtonStyle" TargetType="Button">
+            <Setter Property="Width" Value="16"/>
+            <Setter Property="Height" Value="16"/>
+            <Setter Property="Margin" Value="2"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Grid>
+                            <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5">
+                                <Rectangle.RenderTransform>
+                                    <RotateTransform Angle="45"/>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
 
     <!-- DataContext via the window‐scoped resource -->
@@ -360,17 +380,37 @@
 
                                                 <!-- Position -->
                                                 <TextBlock Text="Position" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0"/>
-                                                <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Row="0" Grid.Column="1" Margin="2"
+                                                <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="20"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="20"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Row="0" Grid.Column="2" Margin="2"
+                                                    <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                    <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                </Grid>
 
                                                 <!-- Scale -->
                                                 <TextBlock Text="Scale" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0"/>
-                                                <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Row="1" Grid.Column="1" Margin="2"
+                                                <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="20"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="20"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Row="1" Grid.Column="2" Margin="2"
+                                                    <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                    <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                </Grid>
 
                                                 <!-- Scale Origin -->
                                                 <TextBlock Text="Scale Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0"/>

--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -213,5 +213,28 @@ namespace PressPlay
                 }
             }
         }
+
+        private void AddKeyframeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.SelectedTrackItem is not TrackItem item) return;
+            if (sender is not Button btn || btn.Tag is not string property) return;
+
+            int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
+            if (!item.Keyframes.TryGetValue(property, out var list)) return;
+
+            var existing = list.FirstOrDefault(k => k.Frame == frame);
+            if (existing != null)
+            {
+                list.Remove(existing);
+            }
+            else
+            {
+                double value = item.GetAnimated(property, frame);
+                list.Add(new Keyframe { Frame = frame, Value = value });
+            }
+
+            item.NotifyKeyframeChange(property);
+        }
     }
 }

--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -574,5 +574,30 @@ namespace PressPlay.Models
             return ordered[^1].Value;
         }
 
+        public void NotifyKeyframeChange(string property)
+        {
+            switch (property)
+            {
+                case nameof(TranslateX):
+                    OnPropertyChanged(nameof(TranslateXKeyframes));
+                    break;
+                case nameof(TranslateY):
+                    OnPropertyChanged(nameof(TranslateYKeyframes));
+                    break;
+                case nameof(Rotation):
+                    OnPropertyChanged(nameof(RotationKeyframes));
+                    break;
+                case nameof(ScaleX):
+                    OnPropertyChanged(nameof(ScaleXKeyframes));
+                    break;
+                case nameof(ScaleY):
+                    OnPropertyChanged(nameof(ScaleYKeyframes));
+                    break;
+                case nameof(Opacity):
+                    OnPropertyChanged(nameof(OpacityKeyframes));
+                    break;
+            }
+        }
+
     }
 }

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -191,7 +191,7 @@
 
         <!-- Keyframe strips -->
         <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000">
-            <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position X">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -210,15 +210,19 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <ItemsControl x:Name="translateYStrip" Height="10" Tag="TranslateY" ItemsSource="{Binding TranslateYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="translateYStrip" Height="10" Tag="TranslateY" ItemsSource="{Binding TranslateYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position Y">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -237,15 +241,19 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <ItemsControl x:Name="rotationStrip" Height="10" Tag="Rotation" ItemsSource="{Binding RotationKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="rotationStrip" Height="10" Tag="Rotation" ItemsSource="{Binding RotationKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Rotation">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -264,15 +272,19 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <ItemsControl x:Name="scaleXStrip" Height="10" Tag="ScaleX" ItemsSource="{Binding ScaleXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="scaleXStrip" Height="10" Tag="ScaleX" ItemsSource="{Binding ScaleXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Scale X">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -291,15 +303,19 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <ItemsControl x:Name="scaleYStrip" Height="10" Tag="ScaleY" ItemsSource="{Binding ScaleYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="scaleYStrip" Height="10" Tag="ScaleY" ItemsSource="{Binding ScaleYKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Scale Y">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -318,15 +334,19 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <ItemsControl x:Name="opacityStrip" Height="10" Tag="Opacity" ItemsSource="{Binding OpacityKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown">
+            <ItemsControl x:Name="opacityStrip" Height="10" Tag="Opacity" ItemsSource="{Binding OpacityKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Opacity">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
@@ -345,11 +365,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="6" Height="6" Fill="Yellow" Stroke="Black"
+                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
-                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown"/>
+                                   MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.RenderTransform>
+                                <RotateTransform Angle="45"/>
+                            </Rectangle.RenderTransform>
+                        </Rectangle>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>


### PR DESCRIPTION
## Summary
- Display keyframes as traditional orange diamond markers on timeline strips
- Add keyframe buttons next to position and scale fields in Properties tab
- Allow properties panel to insert or remove keyframes and refresh timeline

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fcc982288321a178c9c75c82be79