### PR TITLE
Move keyframe controls to properties tab and fix zoom scaling

### DIFF
--- a/PressPlay/Helpers/TrackItemExtensions.cs
+++ b/PressPlay/Helpers/TrackItemExtensions.cs
@@ -5,18 +5,15 @@ namespace PressPlay.Helpers
     public static class TrackItemExtensions
     {
         public static double GetWidth(this ITrackItem item, int zoomLevel)
-            => item.Duration.TotalFrames * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.Duration.TotalFrames, zoomLevel);
 
         public static double GetFadeInXPosition(this ITrackItem item, int zoomLevel)
-            => item.FadeInFrame * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.FadeInFrame, zoomLevel);
 
         public static double GetFadeOutXPosition(this ITrackItem item, int zoomLevel)
-            => item.FadeOutFrame * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.FadeOutFrame, zoomLevel);
+
         public static double GetXPosition(this ITrackItem item, int zoomLevel)
-            => item.Position.TotalFrames * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.Position.TotalFrames, zoomLevel);
     }
 }

--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -364,80 +364,91 @@
                                         <!-- Transform Section -->
                                         <Expander Header="Motion/Transformation" IsExpanded="True" Foreground="White"
                               Visibility="{Binding SelectedTrackItem, Converter={StaticResource NullToVisibilityConverter}}">
-                                            <Grid Margin="10,5,10,5">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="110"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                </Grid.ColumnDefinitions>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
+                                            <StackPanel Margin="10,5,10,5">
+                                                <!-- Quick property sliders -->
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0" Maximum="360" Value="{Binding SelectedTrackItem.Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0" Maximum="1" Value="{Binding SelectedTrackItem.Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged"/>
 
-                                                <!-- Position -->
-                                                <TextBlock Text="Position" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0"/>
-                                                <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2">
+                                                <!-- Detailed property editors -->
+                                                <Grid Margin="0,10,0,0">
                                                     <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="110"/>
                                                         <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
                                                         <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
-                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
-                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                </Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
 
-                                                <!-- Scale -->
-                                                <TextBlock Text="Scale" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0"/>
-                                                <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
+                                                    <!-- Position -->
+                                                    <TextBlock Text="Position" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0"/>
+                                                    <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
+                                                        <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                </Grid>
+                                                        <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    </Grid>
 
-                                                <!-- Scale Origin -->
-                                                <TextBlock Text="Scale Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0"/>
-                                                <TextBox Text="0.00px" Grid.Row="2" Grid.Column="1" Margin="2" IsEnabled="False"
+                                                    <!-- Scale -->
+                                                    <TextBlock Text="Scale" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0"/>
+                                                    <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
+                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                        <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
+                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                        <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    </Grid>
+
+                                                    <!-- Scale Origin -->
+                                                    <TextBlock Text="Scale Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0"/>
+                                                    <TextBox Text="0.00px" Grid.Row="2" Grid.Column="1" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
-                                                <TextBox Text="0.00px" Grid.Row="2" Grid.Column="2" Margin="2" IsEnabled="False"
+                                                    <TextBox Text="0.00px" Grid.Row="2" Grid.Column="2" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
 
-                                                <!-- Rotation -->
-                                                <TextBlock Text="Rotation" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0"/>
-                                                <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="50"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}" 
+                                                    <!-- Rotation -->
+                                                    <TextBlock Text="Rotation" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0"/>
+                                                    <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="50"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}"
                                         Minimum="0" Maximum="360" Grid.Column="0" Margin="2"
                                         Background="#FF3A3A3A" BorderBrush="#FF4A4A4A"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
+                                                        <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                </Grid>
+                                                    </Grid>
 
-                                                <!-- Rotation Origin -->
-                                                <TextBlock Text="Rotation Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0"/>
-                                                <TextBox Text="Center" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" IsEnabled="False"
+                                                    <!-- Rotation Origin -->
+                                                    <TextBlock Text="Rotation Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0"/>
+                                                    <TextBox Text="Center" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
-                                            </Grid>
+                                                </Grid>
+                                            </StackPanel>
                                         </Expander>
 
                                         <!-- Effects Section -->

--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -236,5 +236,27 @@ namespace PressPlay
 
             item.NotifyKeyframeChange(property);
         }
+
+        private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.SelectedTrackItem is not TrackItem item) return;
+            if (sender is not Slider slider || slider.Tag is not string property) return;
+
+            int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
+            if (!item.Keyframes.TryGetValue(property, out var list)) return;
+
+            var existing = list.FirstOrDefault(k => k.Frame == frame);
+            if (existing != null)
+            {
+                existing.Value = e.NewValue;
+            }
+            else
+            {
+                list.Add(new Keyframe { Frame = frame, Value = e.NewValue });
+            }
+
+            item.NotifyKeyframeChange(property);
+        }
     }
 }

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -173,22 +173,6 @@
             </Grid.Style>
         </Grid>
 
-        <!-- Property editors shown when item is selected -->
-        <StackPanel x:Name="PropertyEditors"
-                    Orientation="Vertical"
-                    Panel.ZIndex="3"
-                    Width="120"
-                    Margin="2"
-                    Background="#80000000"
-                    Visibility="{Binding IsSelected, Converter={converters:BoolToVisibilityConverter}}">
-            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0" Maximum="360" Value="{Binding Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0" Maximum="1" Value="{Binding Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged" />
-        </StackPanel>
-
         <!-- Keyframe strips -->
         <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000">
             <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position X">

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -72,34 +72,6 @@ namespace PressPlay.Timeline
             }
         }
 
-        private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            if (sender is Slider slider && DataContext is TrackItem item)
-            {
-                _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
-                var project = _timelineControl?.Project;
-                if (project == null) return;
-
-                int frame = project.NeedlePositionTime.TotalFrames;
-                string property = slider.Tag as string ?? string.Empty;
-
-                if (!item.Keyframes.TryGetValue(property, out var list))
-                    return;
-
-                var existing = list.FirstOrDefault(k => k.Frame == frame);
-                if (existing != null)
-                {
-                    existing.Value = e.NewValue;
-                }
-                else
-                {
-                    list.Add(new Keyframe { Frame = frame, Value = e.NewValue });
-                }
-
-                RefreshKeyframeStrip(property);
-            }
-        }
-
         private void TrackItem_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);


### PR DESCRIPTION
## Summary
- remove in-clip property sliders and expose keyframe sliders in the Properties tab
- handle keyframe updates from property sliders and correct track width math to align with zoom

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff4b54d48321a317a7fbba3cb7ca