### PR TITLE
Move keyframe controls to properties tab and fix zoom scaling

### DIFF
--- a/PressPlay/Converters/FrameToPositionConverter.cs
+++ b/PressPlay/Converters/FrameToPositionConverter.cs
@@ -18,7 +18,7 @@ namespace PressPlay.Converters
                 if (parameter is int zoom)
                     zoomLevel = zoom;
 
-                return frame * Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[zoomLevel];
+                return Constants.FramesToPixels(frame, zoomLevel);
             }
             return 0;
         }
@@ -32,7 +32,7 @@ namespace PressPlay.Converters
                 if (parameter is int zoom)
                     zoomLevel = zoom;
 
-                return (int)(position * Constants.TimelineZooms[zoomLevel] / Constants.TimelinePixelsInSeparator);
+                return Constants.PixelsToFrames(position, zoomLevel);
             }
             return 0;
         }

--- a/PressPlay/Converters/FrameToWidthConverter.cs
+++ b/PressPlay/Converters/FrameToWidthConverter.cs
@@ -18,7 +18,7 @@ namespace PressPlay.Converters
                 if (parameter is int zoom)
                     zoomLevel = zoom;
 
-                return frameCount * Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[zoomLevel];
+                return Constants.FramesToPixels(frameCount, zoomLevel);
             }
             return 0;
         }
@@ -32,7 +32,7 @@ namespace PressPlay.Converters
                 if (parameter is int zoom)
                     zoomLevel = zoom;
 
-                return (int)(width * Constants.TimelineZooms[zoomLevel] / Constants.TimelinePixelsInSeparator);
+                return Constants.PixelsToFrames(width, zoomLevel);
             }
             return 0;
         }

--- a/PressPlay/Converters/NeedlePositionConverter.cs
+++ b/PressPlay/Converters/NeedlePositionConverter.cs
@@ -15,7 +15,7 @@ namespace PressPlay.Converters
                 return 0;
             }
 
-            var x = project.NeedlePositionTime.TotalFrames * Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[project.TimelineZoom];
+            var x = Constants.FramesToPixels(project.NeedlePositionTime.TotalFrames, project.TimelineZoom);
 
             return x;
         }

--- a/PressPlay/Helpers/Constants.cs
+++ b/PressPlay/Helpers/Constants.cs
@@ -11,19 +11,19 @@ namespace PressPlay.Helpers
         // Zoom levels with multipliers
         public static Dictionary<int, double> TimelineZooms = new Dictionary<int, double>
         {
-            { 1, 0.1 },   // 0.2 pixels per frame
-            { 2, 0.3 },   // 0.3 pixels per frame
+            { 1, 0.1 },   // 2.0 pixels per frame
+            { 2, 0.3 },   // 0.7 pixels per frame
             { 3, 0.5 },   // 0.4 pixels per frame
-            { 4, 1.0 },   // 0.6 pixels per frame
-            { 5, 2.0 },   // 0.8 pixels per frame
-            { 6, 3.0 },   // 1.0 pixels per frame
-            { 7, 4.0 },   // 1.2 pixels per frame
-            { 8, 6.0 },   // 1.6 pixels per frame
-            { 9, 8.0 },  // 2.0 pixels per frame
-            { 10, 10.0 }, // 3.0 pixels per frame
-            { 11, 15.0 }, // 4.0 pixels per frame
-            { 12, 20.0 }, // 5.0 pixels per frame
-            { 13, 25.0 }, // 6.0 pixels per frame
+            { 4, 1.0 },   // 0.2 pixels per frame
+            { 5, 2.0 },   // 0.1 pixels per frame
+            { 6, 3.0 },   // 0.07 pixels per frame
+            { 7, 4.0 },   // 0.05 pixels per frame
+            { 8, 6.0 },   // 0.03 pixels per frame
+            { 9, 8.0 },   // 0.025 pixels per frame
+            { 10, 10.0 }, // 0.02 pixels per frame
+            { 11, 15.0 }, // 0.013 pixels per frame
+            { 12, 20.0 }, // 0.01 pixels per frame
+            { 13, 25.0 }, // 0.008 pixels per frame
         };
 
         // Helper method to safely get zoom factor
@@ -46,7 +46,7 @@ namespace PressPlay.Helpers
         // Get the actual scale for a zoom level (pixels per frame)
         public static double GetPixelsPerFrame(int zoomLevel)
         {
-            return TimelinePixelsInSeparator * GetZoomFactor(zoomLevel);
+            return TimelinePixelsInSeparator / GetZoomFactor(zoomLevel);
         }
 
         // Convert timeline frames to pixels at a given zoom level

--- a/PressPlay/Helpers/TrackItemExtensions.cs
+++ b/PressPlay/Helpers/TrackItemExtensions.cs
@@ -5,18 +5,15 @@ namespace PressPlay.Helpers
     public static class TrackItemExtensions
     {
         public static double GetWidth(this ITrackItem item, int zoomLevel)
-            => item.Duration.TotalFrames * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.Duration.TotalFrames, zoomLevel);
 
         public static double GetFadeInXPosition(this ITrackItem item, int zoomLevel)
-            => item.FadeInFrame * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.FadeInFrame, zoomLevel);
 
         public static double GetFadeOutXPosition(this ITrackItem item, int zoomLevel)
-            => item.FadeOutFrame * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.FadeOutFrame, zoomLevel);
+
         public static double GetXPosition(this ITrackItem item, int zoomLevel)
-            => item.Position.TotalFrames * Constants.TimelinePixelsInSeparator
-               / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(item.Position.TotalFrames, zoomLevel);
     }
 }

--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -364,80 +364,91 @@
                                         <!-- Transform Section -->
                                         <Expander Header="Motion/Transformation" IsExpanded="True" Foreground="White"
                               Visibility="{Binding SelectedTrackItem, Converter={StaticResource NullToVisibilityConverter}}">
-                                            <Grid Margin="10,5,10,5">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="110"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                </Grid.ColumnDefinitions>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
+                                            <StackPanel Margin="10,5,10,5">
+                                                <!-- Quick property sliders -->
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0" Maximum="360" Value="{Binding SelectedTrackItem.Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0" Maximum="1" Value="{Binding SelectedTrackItem.Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged"/>
 
-                                                <!-- Position -->
-                                                <TextBlock Text="Position" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0"/>
-                                                <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2">
+                                                <!-- Detailed property editors -->
+                                                <Grid Margin="0,10,0,0">
                                                     <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="110"/>
                                                         <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
                                                         <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
-                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
-                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                </Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
 
-                                                <!-- Scale -->
-                                                <TextBlock Text="Scale" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0"/>
-                                                <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="20"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
+                                                    <!-- Position -->
+                                                    <TextBlock Text="Position" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0"/>
+                                                    <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
+                                                        <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                    <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
-                                                </Grid>
+                                                        <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    </Grid>
 
-                                                <!-- Scale Origin -->
-                                                <TextBlock Text="Scale Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0"/>
-                                                <TextBox Text="0.00px" Grid.Row="2" Grid.Column="1" Margin="2" IsEnabled="False"
+                                                    <!-- Scale -->
+                                                    <TextBlock Text="Scale" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0"/>
+                                                    <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="20"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
+                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                        <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
+                                     Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                                        <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                    </Grid>
+
+                                                    <!-- Scale Origin -->
+                                                    <TextBlock Text="Scale Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0"/>
+                                                    <TextBox Text="0.00px" Grid.Row="2" Grid.Column="1" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
-                                                <TextBox Text="0.00px" Grid.Row="2" Grid.Column="2" Margin="2" IsEnabled="False"
+                                                    <TextBox Text="0.00px" Grid.Row="2" Grid.Column="2" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
 
-                                                <!-- Rotation -->
-                                                <TextBlock Text="Rotation" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0"/>
-                                                <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="50"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}" 
+                                                    <!-- Rotation -->
+                                                    <TextBlock Text="Rotation" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0"/>
+                                                    <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="50"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}"
                                         Minimum="0" Maximum="360" Grid.Column="0" Margin="2"
                                         Background="#FF3A3A3A" BorderBrush="#FF4A4A4A"/>
-                                                    <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
+                                                        <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                </Grid>
+                                                    </Grid>
 
-                                                <!-- Rotation Origin -->
-                                                <TextBlock Text="Rotation Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0"/>
-                                                <TextBox Text="Center" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" IsEnabled="False"
+                                                    <!-- Rotation Origin -->
+                                                    <TextBlock Text="Rotation Origin" Foreground="LightGray" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0"/>
+                                                    <TextBox Text="Center" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
-                                            </Grid>
+                                                </Grid>
+                                            </StackPanel>
                                         </Expander>
 
                                         <!-- Effects Section -->

--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -236,5 +236,27 @@ namespace PressPlay
 
             item.NotifyKeyframeChange(property);
         }
+
+        private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.SelectedTrackItem is not TrackItem item) return;
+            if (sender is not Slider slider || slider.Tag is not string property) return;
+
+            int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
+            if (!item.Keyframes.TryGetValue(property, out var list)) return;
+
+            var existing = list.FirstOrDefault(k => k.Frame == frame);
+            if (existing != null)
+            {
+                existing.Value = e.NewValue;
+            }
+            else
+            {
+                list.Add(new Keyframe { Frame = frame, Value = e.NewValue });
+            }
+
+            item.NotifyKeyframeChange(property);
+        }
     }
 }

--- a/PressPlay/Models/AudioTrackItem.cs
+++ b/PressPlay/Models/AudioTrackItem.cs
@@ -508,14 +508,10 @@ namespace PressPlay.Models
         }
 
         public double GetScaledPosition(int zoomLevel) =>
-            Position.TotalFrames
-            * Constants.TimelinePixelsInSeparator
-            / Constants.TimelineZooms[zoomLevel];
+            Constants.FramesToPixels(Position.TotalFrames, zoomLevel);
 
         public double GetScaledWidth(int zoomLevel) =>
-            Duration.TotalFrames
-            * Constants.TimelinePixelsInSeparator
-            / Constants.TimelineZooms[zoomLevel];
+            Constants.FramesToPixels(Duration.TotalFrames, zoomLevel);
 
         protected void OnPropertyChanged([CallerMemberName] string propName = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));

--- a/PressPlay/Models/Clip.cs
+++ b/PressPlay/Models/Clip.cs
@@ -165,18 +165,12 @@ namespace PressPlay.Models
         // Added missing methods required by ITrackItem interface
         public double GetScaledPosition(int zoomLevel)
         {
-            double zoomFactor = Constants.TimelineZooms.ContainsKey(zoomLevel) ?
-                Constants.TimelineZooms[zoomLevel] : 1.0;
-
-            return Position.TotalFrames * Constants.TimelinePixelsInSeparator / zoomFactor;
+            return Constants.FramesToPixels(Position.TotalFrames, zoomLevel);
         }
 
         public double GetScaledWidth(int zoomLevel)
         {
-            double zoomFactor = Constants.TimelineZooms.ContainsKey(zoomLevel) ?
-                Constants.TimelineZooms[zoomLevel] : 1.0;
-
-            return Duration.TotalFrames * Constants.TimelinePixelsInSeparator / zoomFactor;
+            return Constants.FramesToPixels(Duration.TotalFrames, zoomLevel);
         }
 
         // Helper method for null-safe operations

--- a/PressPlay/Models/ProjectClip.cs
+++ b/PressPlay/Models/ProjectClip.cs
@@ -106,7 +106,7 @@ namespace PressPlay.Models
             return isCompatible;
         }
         public double GetWidth(int zoomLevel)
-            => Length.TotalFrames * Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[zoomLevel];
+            => Constants.FramesToPixels(Length.TotalFrames, zoomLevel);
 
         public string ClipId => Id;
         private VideoCapture _capture;

--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -415,19 +415,13 @@ namespace PressPlay.Models
         // Calculate position based on zoom level
         public double GetScaledPosition(int zoomLevel)
         {
-            double zoomFactor = Constants.TimelineZooms.ContainsKey(zoomLevel) ?
-                Constants.TimelineZooms[zoomLevel] : 1.0;
-
-            return Position.TotalFrames * Constants.TimelinePixelsInSeparator / zoomFactor;
+            return Constants.FramesToPixels(Position.TotalFrames, zoomLevel);
         }
 
         // Calculate width based on zoom level
         public double GetScaledWidth(int zoomLevel)
         {
-            double zoomFactor = Constants.TimelineZooms.ContainsKey(zoomLevel) ?
-                Constants.TimelineZooms[zoomLevel] : 1.0;
-
-            return Duration.TotalFrames * Constants.TimelinePixelsInSeparator / zoomFactor;
+            return Constants.FramesToPixels(Duration.TotalFrames, zoomLevel);
         }
 
         protected void OnPropertyChanged([CallerMemberName] string propName = null)

--- a/PressPlay/Timeline/TimelineControl.xaml.cs
+++ b/PressPlay/Timeline/TimelineControl.xaml.cs
@@ -82,8 +82,8 @@ namespace PressPlay.Timeline
         {
             if (e.PropertyName == nameof(Project.TimelineZoom) || e.PropertyName == nameof(Project.NeedlePositionTime))
             {
-                double left = Project.NeedlePositionTime.TotalFrames * Constants.TimelinePixelsInSeparator
-                              / Constants.TimelineZooms[Project.TimelineZoom];
+                double left = Constants.FramesToPixels(Project.NeedlePositionTime.TotalFrames,
+                                                    Project.TimelineZoom);
                 Canvas.SetLeft(needle, left);
                 needle.BringIntoView();
             }
@@ -191,8 +191,8 @@ namespace PressPlay.Timeline
                 double mouseX = e.GetPosition(tracksControl).X;
                 double itemX = tic.TranslatePoint(new Point(), tracksControl).X;
                 double itemRight = itemX + tic.Width;
-                double frame = Math.Round(mouseX / Constants.TimelinePixelsInSeparator
-                                         * Constants.TimelineZooms[Project.TimelineZoom], MidpointRounding.ToZero);
+                double frame = Math.Round(Constants.PixelsToFrames(mouseX, Project.TimelineZoom),
+                                         MidpointRounding.ToZero);
 
                 _mouseDownElement = tic;
                 _mouseDownX = e.GetPosition(_mouseDownElement).X;
@@ -364,7 +364,7 @@ namespace PressPlay.Timeline
                 double mouseDeltaX = mouseX - _trackMouseDownX;
 
                 // Convert pixel delta to frames accurately
-                double pixelsPerFrame = Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[Project.TimelineZoom];
+                double pixelsPerFrame = Constants.GetPixelsPerFrame(Project.TimelineZoom);
                 int frameDelta = (int)Math.Round(mouseDeltaX / pixelsPerFrame);
 
                 // Calculate new position based on the original position
@@ -393,13 +393,9 @@ namespace PressPlay.Timeline
                 // 1) compute frames under the mouse
                 double x = e.GetPosition(tracksControl).X;
                 double itemX = _mouseDownElement.TranslatePoint(new Point(), tracksControl).X;
-                double frame0 = Math.Round(itemX
-                                    / Constants.TimelinePixelsInSeparator
-                                    * Constants.TimelineZooms[Project.TimelineZoom],
+                double frame0 = Math.Round(Constants.PixelsToFrames(itemX, Project.TimelineZoom),
                                     MidpointRounding.ToZero);
-                double currentFr = Math.Round(x
-                                    / Constants.TimelinePixelsInSeparator
-                                    * Constants.TimelineZooms[Project.TimelineZoom],
+                double currentFr = Math.Round(Constants.PixelsToFrames(x, Project.TimelineZoom),
                                     MidpointRounding.ToZero);
 
                 // 2) how many frames we've moved
@@ -421,11 +417,9 @@ namespace PressPlay.Timeline
             {
                 double x = e.GetPosition(tracksControl).X;
                 double itemX = _mouseDownElement.TranslatePoint(new Point(), tracksControl).X;
-                double frame0 = Math.Round(itemX / Constants.TimelinePixelsInSeparator
-                                           * Constants.TimelineZooms[Project.TimelineZoom],
+                double frame0 = Math.Round(Constants.PixelsToFrames(itemX, Project.TimelineZoom),
                                            MidpointRounding.ToZero);
-                double currentFrame = Math.Round(x / Constants.TimelinePixelsInSeparator
-                                                * Constants.TimelineZooms[Project.TimelineZoom],
+                double currentFrame = Math.Round(Constants.PixelsToFrames(x, Project.TimelineZoom),
                                                 MidpointRounding.ToZero);
                 int diff = (int)(currentFrame - frame0);
 
@@ -457,9 +451,9 @@ namespace PressPlay.Timeline
                 double x = e.GetPosition(_mouseDownElement).X;
                 if (_mouseDownTrackItem.IsChangingFadeOut) x -= _mouseDownElement.Width;
                 x -= 5;
-                int destFrame = Convert.ToInt32(Math.Round(x / Constants.TimelinePixelsInSeparator
-                                                         * Constants.TimelineZooms[Project.TimelineZoom],
-                                                         MidpointRounding.ToZero));
+                int destFrame = Convert.ToInt32(Math.Round(
+                    Constants.PixelsToFrames(x, Project.TimelineZoom),
+                    MidpointRounding.ToZero));
                 if (_mouseDownTrackItem.IsChangingFadeIn)
                 {
                     if (destFrame < 0) destFrame = 0;
@@ -492,12 +486,10 @@ namespace PressPlay.Timeline
         {
             double x = Math.Round(needleXPosition);
             if (x < 0) x = 0;
-            double frame = Math.Round(x / Constants.TimelinePixelsInSeparator
-                                      * Constants.TimelineZooms[Project.TimelineZoom],
+            double frame = Math.Round(Constants.PixelsToFrames(x, Project.TimelineZoom),
                                       MidpointRounding.ToZero);
             frame = GetSnappedFrame((int)frame);
-            double newX = frame * Constants.TimelinePixelsInSeparator
-                          / Constants.TimelineZooms[Project.TimelineZoom];
+            double newX = Constants.FramesToPixels((int)frame, Project.TimelineZoom);
 
             Canvas.SetLeft(needle, newX);
             Project.NeedlePositionTime = new TimeCode((int)frame, Project.FPS);
@@ -517,10 +509,8 @@ namespace PressPlay.Timeline
             //    Use the header control to get X in timeline coords
             double dropX = e.GetPosition(header).X;
             int frame = (int)Math.Round(
-                dropX
-              / Constants.TimelinePixelsInSeparator
-              * Constants.TimelineZooms[Project.TimelineZoom],
-              MidpointRounding.ToZero);
+                Constants.PixelsToFrames(dropX, Project.TimelineZoom),
+                MidpointRounding.ToZero);
             var position = new TimeCode(frame, Project.FPS);
 
             Debug.WriteLine($"Drop position: X={dropX}, Frame={frame}");

--- a/PressPlay/Timeline/TimelineHeaderControl.xaml.cs
+++ b/PressPlay/Timeline/TimelineHeaderControl.xaml.cs
@@ -102,7 +102,7 @@ namespace PressPlay.Timeline
             double totalSeconds = totalFrames / Project.FPS;
 
             // Calculate pixels per frame and per second
-            double pixelsPerFrame = Constants.TimelinePixelsInSeparator / Constants.TimelineZooms[Project.TimelineZoom];
+            double pixelsPerFrame = Constants.GetPixelsPerFrame(Project.TimelineZoom);
             double pixelsPerSecond = pixelsPerFrame * Project.FPS;
 
             // Determine appropriate label interval based on zoom

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -173,22 +173,6 @@
             </Grid.Style>
         </Grid>
 
-        <!-- Property editors shown when item is selected -->
-        <StackPanel x:Name="PropertyEditors"
-                    Orientation="Vertical"
-                    Panel.ZIndex="3"
-                    Width="120"
-                    Margin="2"
-                    Background="#80000000"
-                    Visibility="{Binding IsSelected, Converter={converters:BoolToVisibilityConverter}}">
-            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="-500" Maximum="500" Value="{Binding TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0" Maximum="360" Value="{Binding Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0.1" Maximum="5" Value="{Binding ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged" />
-            <Slider Minimum="0" Maximum="1" Value="{Binding Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged" />
-        </StackPanel>
-
         <!-- Keyframe strips -->
         <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000">
             <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position X">

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -72,34 +72,6 @@ namespace PressPlay.Timeline
             }
         }
 
-        private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
-        {
-            if (sender is Slider slider && DataContext is TrackItem item)
-            {
-                _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
-                var project = _timelineControl?.Project;
-                if (project == null) return;
-
-                int frame = project.NeedlePositionTime.TotalFrames;
-                string property = slider.Tag as string ?? string.Empty;
-
-                if (!item.Keyframes.TryGetValue(property, out var list))
-                    return;
-
-                var existing = list.FirstOrDefault(k => k.Frame == frame);
-                if (existing != null)
-                {
-                    existing.Value = e.NewValue;
-                }
-                else
-                {
-                    list.Add(new Keyframe { Frame = frame, Value = e.NewValue });
-                }
-
-                RefreshKeyframeStrip(property);
-            }
-        }
-
         private void TrackItem_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);

--- a/PressPlay/Utilities/PixelCalculator.cs
+++ b/PressPlay/Utilities/PixelCalculator.cs
@@ -7,7 +7,7 @@ namespace PressPlay.Utilities
     {
         public static double GetPixels(double totalFrames, int zoom)
         {
-            var pixels = totalFrames / Constants.TimelineZooms[zoom] * Constants.TimelinePixelsInSeparator;
+            var pixels = Constants.FramesToPixels((int)totalFrames, zoom);
             return pixels;
         }
     }


### PR DESCRIPTION
## Summary
- remove in-clip property sliders and expose keyframe sliders in the Properties tab
- handle keyframe updates from property sliders and correct track width math to align with zoom
- ensure zoom level 1 magnifies clips and level 13 zooms out by centralizing frame/pixel conversions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff4b54d48321a317a7fbba3cb7ca