### PR TITLE
feat: improve keyframe controls

### DIFF
--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -347,9 +347,9 @@
                                                         <ColumnDefinition Width="*"/>
                                                         <ColumnDefinition Width="50"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <Slider Value="{Binding SelectedTrackItem.Opacity, Mode=TwoWay}" 
+                                                    <Slider Value="{Binding SelectedTrackItem.Opacity, Mode=TwoWay}"
                                         Minimum="0" Maximum="1" Grid.Column="0" Margin="2"
-                                        Background="#FF3A3A3A" BorderBrush="#FF4A4A4A"/>
+                                        Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged"/>
                                                     <TextBox Text="{Binding SelectedTrackItem.Opacity, StringFormat=P0, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
                                                 </Grid>
@@ -365,16 +365,10 @@
                                         <Expander Header="Motion/Transformation" IsExpanded="True" Foreground="White"
                               Visibility="{Binding SelectedTrackItem, Converter={StaticResource NullToVisibilityConverter}}">
                                             <StackPanel Margin="10,5,10,5">
-                                                <!-- Quick property sliders -->
-                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"/>
-                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"/>
-                                                <Slider Minimum="0" Maximum="360" Value="{Binding SelectedTrackItem.Rotation}" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"/>
-                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"/>
-                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"/>
-                                                <Slider Minimum="0" Maximum="1" Value="{Binding SelectedTrackItem.Opacity}" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <CheckBox Content="Enable Keyframes" Foreground="White" IsChecked="{Binding SelectedTrackItem.KeyframesEnabled}" Margin="0,0,0,10" Checked="KeyframeToggle_Checked" Unchecked="KeyframeToggle_Unchecked"/>
 
                                                 <!-- Detailed property editors -->
-                                                <Grid Margin="0,10,0,0">
+                                                <Grid>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="110"/>
                                                         <ColumnDefinition Width="*"/>
@@ -399,10 +393,10 @@
                                                         </Grid.ColumnDefinitions>
                                                         <TextBox Text="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                        <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <Button Grid.Column="1" Tag="TranslateX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}" IsEnabled="{Binding SelectedTrackItem.KeyframesEnabled}"/>
                                                         <TextBox Text="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                        <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <Button Grid.Column="3" Tag="TranslateY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}" IsEnabled="{Binding SelectedTrackItem.KeyframesEnabled}"/>
                                                     </Grid>
 
                                                     <!-- Scale -->
@@ -416,10 +410,10 @@
                                                         </Grid.ColumnDefinitions>
                                                         <TextBox Text="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Grid.Column="0" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                        <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <Button Grid.Column="1" Tag="ScaleX" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}" IsEnabled="{Binding SelectedTrackItem.KeyframesEnabled}"/>
                                                         <TextBox Text="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Grid.Column="2" Margin="2"
                                      Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
-                                                        <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}"/>
+                                                        <Button Grid.Column="3" Tag="ScaleY" Click="AddKeyframeButton_Click" Style="{StaticResource KeyframeButtonStyle}" IsEnabled="{Binding SelectedTrackItem.KeyframesEnabled}"/>
                                                     </Grid>
 
                                                     <!-- Scale Origin -->
@@ -436,9 +430,7 @@
                                                             <ColumnDefinition Width="*"/>
                                                             <ColumnDefinition Width="50"/>
                                                         </Grid.ColumnDefinitions>
-                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}"
-                                        Minimum="0" Maximum="360" Grid.Column="0" Margin="2"
-                                        Background="#FF3A3A3A" BorderBrush="#FF4A4A4A"/>
+                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}" Minimum="0" Maximum="360" Grid.Column="0" Margin="2" Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"/>
                                                         <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
                                                     </Grid>
@@ -448,6 +440,15 @@
                                                     <TextBox Text="Center" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="2" IsEnabled="False"
                                      Background="#FF3A3A3A" Foreground="Gray" BorderBrush="#FF4A4A4A"/>
                                                 </Grid>
+                                                <!-- Sliders with labels -->
+                                                <TextBlock Text="Transform X" Foreground="LightGray" Margin="0,10,0,0"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <TextBlock Text="Transform Y" Foreground="LightGray"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <TextBlock Text="Scale X" Foreground="LightGray" Margin="0,10,0,0"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <TextBlock Text="Scale Y" Foreground="LightGray"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"/>
                                             </StackPanel>
                                         </Expander>
 

--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -220,6 +220,8 @@ namespace PressPlay
             if (vm.SelectedTrackItem is not TrackItem item) return;
             if (sender is not Button btn || btn.Tag is not string property) return;
 
+            if (!item.KeyframesEnabled) return;
+
             int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
             if (!item.Keyframes.TryGetValue(property, out var list)) return;
 
@@ -243,6 +245,8 @@ namespace PressPlay
             if (vm.SelectedTrackItem is not TrackItem item) return;
             if (sender is not Slider slider || slider.Tag is not string property) return;
 
+            if (!item.KeyframesEnabled) return;
+
             int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
             if (!item.Keyframes.TryGetValue(property, out var list)) return;
 
@@ -257,6 +261,46 @@ namespace PressPlay
             }
 
             item.NotifyKeyframeChange(property);
+        }
+
+        private void KeyframeToggle_Checked(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is MainWindowViewModel vm && vm.SelectedTrackItem is TrackItem item)
+            {
+                item.KeyframesEnabled = true;
+            }
+        }
+
+        private void KeyframeToggle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.SelectedTrackItem is not TrackItem item) return;
+
+            bool hasKeyframes = item.Keyframes.Any(kv => kv.Value.Count > 0);
+            if (hasKeyframes)
+            {
+                var result = MessageBox.Show("Disabling keyframes will delete existing keyframes. Continue?", "Disable Keyframes", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (result != MessageBoxResult.Yes)
+                {
+                    item.KeyframesEnabled = true;
+                    if (sender is CheckBox cb) cb.IsChecked = true;
+                    return;
+                }
+            }
+
+            foreach (var list in item.Keyframes.Values)
+            {
+                list.Clear();
+            }
+            foreach (var key in item.Keyframes.Keys.ToList())
+            {
+                item.NotifyKeyframeChange(key);
+            }
+
+            int frame = vm.CurrentProject.NeedlePositionTime.TotalFrames;
+            item.EvaluateKeyframes(frame);
+
+            item.KeyframesEnabled = false;
         }
     }
 }

--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -497,6 +497,14 @@ namespace PressPlay.Models
             set => SetField(ref _opacity, value);
         }
 
+        private bool _keyframesEnabled = true;
+        [JsonInclude]
+        public bool KeyframesEnabled
+        {
+            get => _keyframesEnabled;
+            set => SetField(ref _keyframesEnabled, value);
+        }
+
         [JsonInclude]
         public Dictionary<string, List<Keyframe>> Keyframes { get; } = new()
         {

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -15,6 +15,10 @@
         SizeChanged="Border_SizeChanged"
         d:DesignHeight="50" d:DesignWidth="100">
 
+    <Border.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Border.Resources>
+
     <!-- width = clip duration -->
     <Border.Width>
         <MultiBinding Converter="{converters:TrackItemDataToLengthConverter}">
@@ -174,7 +178,12 @@
         </Grid>
 
         <!-- Keyframe strips -->
-        <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000">
+        <StackPanel x:Name="KeyframePanel" Orientation="Vertical" VerticalAlignment="Bottom" Panel.ZIndex="2" Background="#40000000" Visibility="{Binding KeyframesEnabled, Converter={StaticResource BoolToVis}}">
+            <StackPanel.Resources>
+                <Style TargetType="ItemsControl">
+                    <Setter Property="Width" Value="{Binding ElementName=itemControl, Path=ActualWidth}"/>
+                </Style>
+            </StackPanel.Resources>
             <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position X">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate><Canvas/></ItemsPanelTemplate>
@@ -194,7 +203,7 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
+                        <Rectangle Width="8" Height="8" Fill="Red" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
@@ -256,7 +265,7 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
+                        <Rectangle Width="8" Height="8" Fill="Yellow" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
@@ -287,7 +296,7 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
+                        <Rectangle Width="8" Height="8" Fill="Green" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
@@ -318,7 +327,7 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
+                        <Rectangle Width="8" Height="8" Fill="Blue" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
@@ -349,7 +358,7 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
+                        <Rectangle Width="8" Height="8" Fill="Purple" Stroke="Black" RenderTransformOrigin="0.5,0.5"
                                    MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -249,6 +249,7 @@ namespace PressPlay.Timeline
         {
             if (sender is ItemsControl strip && DataContext is TrackItem item)
             {
+                if (!item.KeyframesEnabled) return;
                 _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
                 var project = _timelineControl?.Project;
                 if (project == null) return;
@@ -312,7 +313,27 @@ namespace PressPlay.Timeline
                 if (item.Keyframes.TryGetValue(property, out var list))
                 {
                     list.Remove(kf);
+                    item.NotifyKeyframeChange(property);
                     RefreshKeyframeStrip(property);
+
+                    if (list.Count == 0)
+                    {
+                        switch (property)
+                        {
+                            case nameof(TrackItem.TranslateX): item.TranslateX = 0; break;
+                            case nameof(TrackItem.TranslateY): item.TranslateY = 0; break;
+                            case nameof(TrackItem.Rotation): item.Rotation = 0; break;
+                            case nameof(TrackItem.ScaleX): item.ScaleX = 1; break;
+                            case nameof(TrackItem.ScaleY): item.ScaleY = 1; break;
+                            case nameof(TrackItem.Opacity): item.Opacity = 1; break;
+                        }
+                    }
+                    else
+                    {
+                        _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
+                        int frame = _timelineControl?.Project?.NeedlePositionTime.TotalFrames ?? 0;
+                        item.EvaluateKeyframes(frame);
+                    }
                 }
                 e.Handled = true;
             }


### PR DESCRIPTION
## Summary
- add toggle to enable/disable keyframes and organize labeled motion sliders
- color-code keyframe diamonds and hide strips when keyframes are disabled
- allow keyframe removal to restore default values and respect keyframe toggle
- fix keyframe diamond visibility and match toggle text color with UI

## Testing
- `dotnet build PressPlay.sln` *(fails: command not found: dotnet)*
- `dotnet test PressPlay.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c70749fb10832194a8e3caf43e8227