### PR TITLE
Render keyframe markers

### DIFF
--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -506,28 +506,28 @@ namespace PressPlay.Models
         }
 
         [JsonInclude]
-        public Dictionary<string, List<Keyframe>> Keyframes { get; } = new()
+        public Dictionary<string, ObservableCollection<Keyframe>> Keyframes { get; } = new()
         {
-            [nameof(TranslateX)] = new List<Keyframe>(),
-            [nameof(TranslateY)] = new List<Keyframe>(),
-            [nameof(Rotation)] = new List<Keyframe>(),
-            [nameof(ScaleX)] = new List<Keyframe>(),
-            [nameof(ScaleY)] = new List<Keyframe>(),
-            [nameof(Opacity)] = new List<Keyframe>(),
+            [nameof(TranslateX)] = new ObservableCollection<Keyframe>(),
+            [nameof(TranslateY)] = new ObservableCollection<Keyframe>(),
+            [nameof(Rotation)]  = new ObservableCollection<Keyframe>(),
+            [nameof(ScaleX)]    = new ObservableCollection<Keyframe>(),
+            [nameof(ScaleY)]    = new ObservableCollection<Keyframe>(),
+            [nameof(Opacity)]   = new ObservableCollection<Keyframe>(),
         };
 
         [JsonIgnore]
-        public List<Keyframe> TranslateXKeyframes => Keyframes[nameof(TranslateX)];
+        public ObservableCollection<Keyframe> TranslateXKeyframes => Keyframes[nameof(TranslateX)];
         [JsonIgnore]
-        public List<Keyframe> TranslateYKeyframes => Keyframes[nameof(TranslateY)];
+        public ObservableCollection<Keyframe> TranslateYKeyframes => Keyframes[nameof(TranslateY)];
         [JsonIgnore]
-        public List<Keyframe> RotationKeyframes => Keyframes[nameof(Rotation)];
+        public ObservableCollection<Keyframe> RotationKeyframes  => Keyframes[nameof(Rotation)];
         [JsonIgnore]
-        public List<Keyframe> ScaleXKeyframes => Keyframes[nameof(ScaleX)];
+        public ObservableCollection<Keyframe> ScaleXKeyframes    => Keyframes[nameof(ScaleX)];
         [JsonIgnore]
-        public List<Keyframe> ScaleYKeyframes => Keyframes[nameof(ScaleY)];
+        public ObservableCollection<Keyframe> ScaleYKeyframes    => Keyframes[nameof(ScaleY)];
         [JsonIgnore]
-        public List<Keyframe> OpacityKeyframes => Keyframes[nameof(Opacity)];
+        public ObservableCollection<Keyframe> OpacityKeyframes   => Keyframes[nameof(Opacity)];
 
         public void EvaluateKeyframes(int frame)
         {

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -425,12 +425,12 @@ namespace PressPlay.Serialization
                 {
                     try
                     {
-                        var dict = JsonSerializer.Deserialize<Dictionary<string, List<Keyframe>>>(kfElement.GetRawText(), options);
+                        var dict = JsonSerializer.Deserialize<Dictionary<string, ObservableCollection<Keyframe>>>(kfElement.GetRawText(), options);
                         if (dict != null)
                         {
                             foreach (var kv in dict)
                             {
-                                ti.Keyframes[kv.Key] = kv.Value ?? new List<Keyframe>();
+                                ti.Keyframes[kv.Key] = kv.Value ?? new ObservableCollection<Keyframe>();
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- use observable collections for keyframe strips so timeline refreshes
- update project serialization to load observable keyframe collections

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c70c5ccf9483218774c03d06d42251