### PR TITLE
Prevent keyframe creation during playback

### DIFF
--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -217,6 +217,7 @@ namespace PressPlay
         private void AddKeyframeButton_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.CurrentProject.IsPlaying) return;
             if (vm.SelectedTrackItem is not TrackItem item) return;
             if (sender is not Button btn || btn.Tag is not string property) return;
 
@@ -242,6 +243,7 @@ namespace PressPlay
         private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (DataContext is not MainWindowViewModel vm) return;
+            if (vm.CurrentProject.IsPlaying) return;
             if (vm.SelectedTrackItem is not TrackItem item) return;
             if (sender is not Slider slider || slider.Tag is not string property) return;
 

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -252,7 +252,7 @@ namespace PressPlay.Timeline
                 if (!item.KeyframesEnabled) return;
                 _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
                 var project = _timelineControl?.Project;
-                if (project == null) return;
+                if (project == null || project.IsPlaying) return;
 
                 if (e.OriginalSource is Canvas)
                 {


### PR DESCRIPTION
## Summary
- Avoid adding keyframes when playback is active
- Ignore keyframe strip clicks during playback

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c70e5a765c8321bfe2d74472346a06