### PR TITLE
Add color correction and disable keyframes by default

### DIFF
--- a/PressPlay.Tests/ProjectSerializationTests.cs
+++ b/PressPlay.Tests/ProjectSerializationTests.cs
@@ -58,4 +58,64 @@ public class ProjectSerializationTests
         loadedItem.EvaluateKeyframes(0);
         Assert.Equal(12.5, loadedItem.TranslateX);
     }
+
+    [Fact]
+    public void KeyframesEnabled_Persists_WhenSerialized()
+    {
+        var project = new Project { FPS = 25 };
+        var track = new Track { Name = "V1" };
+        var item = new TrackItem
+        {
+            Position = new TimeCode(0, 25),
+            Start = new TimeCode(0, 25),
+            End = new TimeCode(5, 25),
+            OriginalEnd = new TimeCode(5, 25),
+            SourceLength = new TimeCode(5, 25),
+            FileName = "clip.mp4",
+            FilePath = "clip.mp4",
+            FullPath = "clip.mp4",
+            KeyframesEnabled = true
+        };
+        track.Items.Add(item);
+        project.Tracks.Add(track);
+
+        var json = ProjectSerializer.SerializeProject(project);
+        var loaded = ProjectSerializer.DeserializeProject(json);
+        var loadedItem = Assert.IsType<TrackItem>(loaded.Tracks[0].Items[0]);
+        Assert.True(loadedItem.KeyframesEnabled);
+    }
+
+    [Fact]
+    public void ColorCorrection_Properties_Persist()
+    {
+        var project = new Project { FPS = 25 };
+        var track = new Track { Name = "V1" };
+        var item = new TrackItem
+        {
+            Position = new TimeCode(0, 25),
+            Start = new TimeCode(0, 25),
+            End = new TimeCode(5, 25),
+            OriginalEnd = new TimeCode(5, 25),
+            SourceLength = new TimeCode(5, 25),
+            FileName = "clip.mp4",
+            FilePath = "clip.mp4",
+            FullPath = "clip.mp4",
+            Brightness = 10,
+            Contrast = 1.5,
+            Gamma = 0.8,
+            Hue = 30,
+            Saturation = 1.2
+        };
+        track.Items.Add(item);
+        project.Tracks.Add(track);
+
+        var json = ProjectSerializer.SerializeProject(project);
+        var loaded = ProjectSerializer.DeserializeProject(json);
+        var loadedItem = Assert.IsType<TrackItem>(loaded.Tracks[0].Items[0]);
+        Assert.Equal(10, loadedItem.Brightness);
+        Assert.Equal(1.5, loadedItem.Contrast);
+        Assert.Equal(0.8, loadedItem.Gamma);
+        Assert.Equal(30, loadedItem.Hue);
+        Assert.Equal(1.2, loadedItem.Saturation);
+    }
 }

--- a/PressPlay/CustomControls/ColorWheelControl.xaml
+++ b/PressPlay/CustomControls/ColorWheelControl.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="PressPlay.CustomControls.ColorWheelControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Canvas>
+        <Image x:Name="WheelImage" Stretch="Fill"/>
+        <Ellipse x:Name="Selector" Width="10" Height="10" Stroke="White" StrokeThickness="2" Fill="Transparent"/>
+    </Canvas>
+</UserControl>

--- a/PressPlay/CustomControls/ColorWheelControl.xaml.cs
+++ b/PressPlay/CustomControls/ColorWheelControl.xaml.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace PressPlay.CustomControls
+{
+    public partial class ColorWheelControl : UserControl
+    {
+        public static readonly DependencyProperty HueProperty =
+            DependencyProperty.Register(nameof(Hue), typeof(double), typeof(ColorWheelControl),
+                new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHueChanged));
+
+        public static readonly DependencyProperty SaturationProperty =
+            DependencyProperty.Register(nameof(Saturation), typeof(double), typeof(ColorWheelControl),
+                new FrameworkPropertyMetadata(1.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSaturationChanged));
+
+        public double Hue
+        {
+            get => (double)GetValue(HueProperty);
+            set => SetValue(HueProperty, value);
+        }
+
+        public double Saturation
+        {
+            get => (double)GetValue(SaturationProperty);
+            set => SetValue(SaturationProperty, value);
+        }
+
+        private bool _dragging;
+
+        public ColorWheelControl()
+        {
+            InitializeComponent();
+            Loaded += (_, _) => RenderWheel();
+            SizeChanged += (_, _) => RenderWheel();
+            MouseDown += OnMouseDown;
+            MouseMove += OnMouseMove;
+            MouseUp += (_, _) => { _dragging = false; ReleaseMouseCapture(); };
+        }
+
+        private void OnMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            _dragging = true;
+            CaptureMouse();
+            UpdateFromPoint(e.GetPosition(this));
+        }
+
+        private void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (_dragging)
+                UpdateFromPoint(e.GetPosition(this));
+        }
+
+        private void UpdateFromPoint(Point p)
+        {
+            double size = Math.Min(ActualWidth, ActualHeight);
+            double cx = size / 2;
+            double cy = size / 2;
+            double dx = p.X - cx;
+            double dy = p.Y - cy;
+            double radius = Math.Sqrt(dx * dx + dy * dy);
+            double maxRadius = size / 2;
+            Saturation = Math.Min(1.0, radius / maxRadius);
+            Hue = (Math.Atan2(dy, dx) * 180 / Math.PI + 360) % 360;
+            UpdateSelector();
+        }
+
+        private void RenderWheel()
+        {
+            int size = (int)Math.Min(ActualWidth, ActualHeight);
+            if (size <= 0) return;
+            int stride = size * 4;
+            byte[] pixels = new byte[size * stride];
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    double dx = x - size / 2.0;
+                    double dy = y - size / 2.0;
+                    double radius = Math.Sqrt(dx * dx + dy * dy);
+                    if (radius > size / 2.0)
+                        continue;
+                    double hue = (Math.Atan2(dy, dx) * 180 / Math.PI + 360) % 360;
+                    double sat = radius / (size / 2.0);
+                    var c = ColorFromHSV(hue, sat, 1.0);
+                    int index = y * stride + x * 4;
+                    pixels[index] = c.B;
+                    pixels[index + 1] = c.G;
+                    pixels[index + 2] = c.R;
+                    pixels[index + 3] = 255;
+                }
+            }
+            var wb = new WriteableBitmap(size, size, 96, 96, PixelFormats.Bgra32, null);
+            wb.WritePixels(new Int32Rect(0, 0, size, size), pixels, stride, 0);
+            WheelImage.Width = size;
+            WheelImage.Height = size;
+            WheelImage.Source = wb;
+            UpdateSelector();
+        }
+
+        private static Color ColorFromHSV(double hue, double saturation, double value)
+        {
+            double c = value * saturation;
+            double x = c * (1 - Math.Abs((hue / 60.0) % 2 - 1));
+            double m = value - c;
+            double r = 0, g = 0, b = 0;
+            if (hue < 60) { r = c; g = x; }
+            else if (hue < 120) { r = x; g = c; }
+            else if (hue < 180) { g = c; b = x; }
+            else if (hue < 240) { g = x; b = c; }
+            else if (hue < 300) { r = x; b = c; }
+            else { r = c; b = x; }
+            return Color.FromRgb((byte)((r + m) * 255), (byte)((g + m) * 255), (byte)((b + m) * 255));
+        }
+
+        private void UpdateSelector()
+        {
+            double size = Math.Min(ActualWidth, ActualHeight);
+            double radius = Saturation * size / 2;
+            double rad = Hue * Math.PI / 180;
+            double x = size / 2 + radius * Math.Cos(rad);
+            double y = size / 2 + radius * Math.Sin(rad);
+            Canvas.SetLeft(Selector, x - Selector.Width / 2);
+            Canvas.SetTop(Selector, y - Selector.Height / 2);
+        }
+
+        private static void OnHueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ColorWheelControl)d).UpdateSelector();
+        }
+
+        private static void OnSaturationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((ColorWheelControl)d).UpdateSelector();
+        }
+    }
+}

--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -499,6 +499,33 @@
                         </Grid>
                     </TabItem>
 
+                    <TabItem Header="Color Correction">
+                        <Grid>
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <StackPanel Margin="5">
+                                    <TextBlock Text="Select a clip to adjust color" Foreground="LightGray"
+                                               Visibility="{Binding SelectedTrackItem, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=true}"
+                                               HorizontalAlignment="Center" Margin="0,20,0,0"/>
+
+                                    <StackPanel Visibility="{Binding SelectedTrackItem, Converter={StaticResource NullToVisibilityConverter}}">
+                                        <customcontrols:ColorWheelControl Width="150" Height="150" Margin="0,0,0,10"
+                                                                         Hue="{Binding SelectedTrackItem.Hue, Mode=TwoWay}"
+                                                                         Saturation="{Binding SelectedTrackItem.Saturation, Mode=TwoWay}"/>
+
+                                        <TextBlock Text="Brightness" Foreground="LightGray"/>
+                                        <Slider Minimum="-100" Maximum="100" Value="{Binding SelectedTrackItem.Brightness, Mode=TwoWay}"/>
+
+                                        <TextBlock Text="Contrast" Foreground="LightGray" Margin="0,10,0,0"/>
+                                        <Slider Minimum="0" Maximum="3" Value="{Binding SelectedTrackItem.Contrast, Mode=TwoWay}"/>
+
+                                        <TextBlock Text="Gamma" Foreground="LightGray" Margin="0,10,0,0"/>
+                                        <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.Gamma, Mode=TwoWay}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Grid>
+                    </TabItem>
+
                 </TabControl>
             </Grid>
 

--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -497,7 +497,48 @@ namespace PressPlay.Models
             set => SetField(ref _opacity, value);
         }
 
-        private bool _keyframesEnabled = true;
+        // COLOR CORRECTION
+        private double _brightness = 0.0; // add/subtract per pixel
+        [JsonInclude]
+        public double Brightness
+        {
+            get => _brightness;
+            set => SetField(ref _brightness, value);
+        }
+
+        private double _contrast = 1.0; // multiplier
+        [JsonInclude]
+        public double Contrast
+        {
+            get => _contrast;
+            set => SetField(ref _contrast, value);
+        }
+
+        private double _gamma = 1.0; // gamma curve
+        [JsonInclude]
+        public double Gamma
+        {
+            get => _gamma;
+            set => SetField(ref _gamma, value);
+        }
+
+        private double _hue = 0.0; // hue shift degrees (0-360)
+        [JsonInclude]
+        public double Hue
+        {
+            get => _hue;
+            set => SetField(ref _hue, value);
+        }
+
+        private double _saturation = 1.0; // saturation multiplier
+        [JsonInclude]
+        public double Saturation
+        {
+            get => _saturation;
+            set => SetField(ref _saturation, value);
+        }
+
+        private bool _keyframesEnabled = false;
         [JsonInclude]
         public bool KeyframesEnabled
         {

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -420,6 +420,21 @@ namespace PressPlay.Serialization
                 if (root.TryGetProperty("Volume", out var volumeElement))
                     ti.Volume = volumeElement.GetSingle();
 
+                bool hasKeyframesEnabledProp = root.TryGetProperty("KeyframesEnabled", out var kfEnabled);
+                if (hasKeyframesEnabledProp)
+                    ti.KeyframesEnabled = kfEnabled.GetBoolean();
+
+                if (root.TryGetProperty("Brightness", out var br))
+                    ti.Brightness = br.GetDouble();
+                if (root.TryGetProperty("Contrast", out var ct))
+                    ti.Contrast = ct.GetDouble();
+                if (root.TryGetProperty("Gamma", out var gm))
+                    ti.Gamma = gm.GetDouble();
+                if (root.TryGetProperty("Hue", out var hue))
+                    ti.Hue = hue.GetDouble();
+                if (root.TryGetProperty("Saturation", out var sat))
+                    ti.Saturation = sat.GetDouble();
+
                 // Keyframe dictionary (optional for backward compatibility)
                 if (root.TryGetProperty("Keyframes", out var kfElement))
                 {
@@ -438,6 +453,13 @@ namespace PressPlay.Serialization
                     {
                         Debug.WriteLine($"Failed to deserialize keyframes: {ex.Message}");
                     }
+                }
+
+                if (!hasKeyframesEnabledProp)
+                {
+                    // Backward compatibility: enable if any keyframes exist
+                    if (ti.Keyframes.Any(kv => kv.Value.Count > 0))
+                        ti.KeyframesEnabled = true;
                 }
             }
 
@@ -520,6 +542,12 @@ namespace PressPlay.Serialization
                 writer.WriteNumber("Y", ti.RotationOrigin.Y);
                 writer.WriteEndObject();
                 writer.WriteNumber("Volume", ti.Volume);
+                writer.WriteBoolean("KeyframesEnabled", ti.KeyframesEnabled);
+                writer.WriteNumber("Brightness", ti.Brightness);
+                writer.WriteNumber("Contrast", ti.Contrast);
+                writer.WriteNumber("Gamma", ti.Gamma);
+                writer.WriteNumber("Hue", ti.Hue);
+                writer.WriteNumber("Saturation", ti.Saturation);
 
                 // Serialize keyframe dictionary
                 writer.WritePropertyName("Keyframes");

--- a/PressPlay/Services/ColorCorrectionService.cs
+++ b/PressPlay/Services/ColorCorrectionService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Windows.Media.Imaging;
+using OpenCvSharp;
+using OpenCvSharp.WpfExtensions;
+using PressPlay.Models;
+
+namespace PressPlay.Services
+{
+    public static class ColorCorrectionService
+    {
+        public static BitmapSource Apply(BitmapSource source, TrackItem item)
+        {
+            if (source == null)
+                return source;
+            if (item == null)
+                return source;
+
+            // Skip processing when default values
+            bool needHueSat = Math.Abs(item.Hue) > 0.001 || Math.Abs(item.Saturation - 1.0) > 0.001;
+            bool needBc = Math.Abs(item.Brightness) > 0.001 || Math.Abs(item.Contrast - 1.0) > 0.001;
+            bool needGamma = Math.Abs(item.Gamma - 1.0) > 0.001;
+            if (!needHueSat && !needBc && !needGamma)
+                return source;
+
+            using var mat = BitmapSourceConverter.ToMat(source);
+
+            if (needHueSat)
+            {
+                using var hsv = new Mat();
+                Cv2.CvtColor(mat, hsv, ColorConversionCodes.BGR2HSV);
+                Mat[] channels = Cv2.Split(hsv);
+                if (Math.Abs(item.Hue) > 0.001)
+                {
+                    Cv2.Add(channels[0], new Scalar(item.Hue / 2.0), channels[0]);
+                    Cv2.Min(channels[0], new Scalar(179), channels[0]);
+                }
+                if (Math.Abs(item.Saturation - 1.0) > 0.001)
+                {
+                    Cv2.Multiply(channels[1], new Scalar(item.Saturation), channels[1]);
+                    Cv2.Min(channels[1], new Scalar(255), channels[1]);
+                }
+                Cv2.Merge(channels, hsv);
+                Cv2.CvtColor(hsv, mat, ColorConversionCodes.HSV2BGR);
+                foreach (var c in channels)
+                    c.Dispose();
+            }
+
+            if (needBc)
+            {
+                mat.ConvertTo(mat, -1, item.Contrast, item.Brightness);
+            }
+
+            if (needGamma)
+            {
+                byte[] lut = new byte[256];
+                for (int i = 0; i < 256; i++)
+                {
+                    lut[i] = (byte)(Math.Pow(i / 255.0, 1.0 / item.Gamma) * 255.0);
+                }
+                using var lutMat = new Mat(1, 256, MatType.CV_8UC1, lut);
+                Cv2.LUT(mat, lutMat, mat);
+            }
+
+            return BitmapSourceConverter.ToBitmapSource(mat);
+        }
+    }
+}

--- a/PressPlay/Services/PlaybackService.cs
+++ b/PressPlay/Services/PlaybackService.cs
@@ -405,6 +405,11 @@ namespace PressPlay.Services
             double clipSeconds = clipFrame / clip.FPS;
             var bmp = clip.GetFrameAt(TimeSpan.FromSeconds(clipSeconds));
 
+            if (item is TrackItem ccTi)
+            {
+                bmp = ColorCorrectionService.Apply(bmp, ccTi);
+            }
+
             // C) Compute fade parameters
             double framePos = idx - item.Position.TotalFrames;
             double dur = item.Duration.TotalFrames;


### PR DESCRIPTION
## Summary
- disable keyframes by default and persist toggle in project files
- add color correction tab with color wheel and brightness/contrast/gamma controls
- serialize color correction settings and implement OpenCV-based correction

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71055cd2c8321a2616583e199600b