### PR TITLE
Add color correction tools and default keyframes off

### DIFF
--- a/PressPlay/CustomControls/ColorWheel.xaml
+++ b/PressPlay/CustomControls/ColorWheel.xaml
@@ -1,0 +1,9 @@
+<UserControl x:Class="PressPlay.CustomControls.ColorWheel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="200" Height="200">
+    <Canvas x:Name="RootCanvas" Width="200" Height="200">
+        <Image x:Name="WheelImage" Width="200" Height="200"/>
+        <Ellipse x:Name="Selector" Width="10" Height="10" Stroke="White" StrokeThickness="2" Fill="Transparent" Visibility="Collapsed"/>
+    </Canvas>
+</UserControl>

--- a/PressPlay/CustomControls/ColorWheel.xaml.cs
+++ b/PressPlay/CustomControls/ColorWheel.xaml.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace PressPlay.CustomControls
+{
+    public partial class ColorWheel : UserControl
+    {
+        public static readonly DependencyProperty SelectedColorProperty =
+            DependencyProperty.Register(
+                nameof(SelectedColor),
+                typeof(Color),
+                typeof(ColorWheel),
+                new FrameworkPropertyMetadata(Colors.White, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public Color SelectedColor
+        {
+            get => (Color)GetValue(SelectedColorProperty);
+            set => SetValue(SelectedColorProperty, value);
+        }
+
+        private int _size = 200;
+        private Point _center;
+
+        public ColorWheel()
+        {
+            InitializeComponent();
+            Loaded += ColorWheel_Loaded;
+            WheelImage.MouseDown += WheelImage_MouseDown;
+            WheelImage.MouseMove += WheelImage_MouseMove;
+        }
+
+        private void ColorWheel_Loaded(object sender, RoutedEventArgs e)
+        {
+            _center = new Point(_size / 2.0, _size / 2.0);
+            GenerateWheel();
+        }
+
+        private void GenerateWheel()
+        {
+            int stride = _size * 4;
+            byte[] pixels = new byte[stride * _size];
+            for (int y = 0; y < _size; y++)
+            {
+                for (int x = 0; x < _size; x++)
+                {
+                    double dx = x - _center.X;
+                    double dy = y - _center.Y;
+                    double r = Math.Sqrt(dx * dx + dy * dy) / (_size / 2.0);
+                    int index = y * stride + x * 4;
+                    if (r <= 1)
+                    {
+                        double angle = Math.Atan2(dy, dx);
+                        double hue = (angle * 180 / Math.PI + 360) % 360;
+                        Color c = HsvToColor(hue, r, 1);
+                        pixels[index] = c.B;
+                        pixels[index + 1] = c.G;
+                        pixels[index + 2] = c.R;
+                        pixels[index + 3] = 255;
+                    }
+                    else
+                    {
+                        pixels[index + 3] = 0;
+                    }
+                }
+            }
+            var bmp = BitmapSource.Create(_size, _size, 96, 96, PixelFormats.Bgra32, null, pixels, stride);
+            WheelImage.Source = bmp;
+        }
+
+        private void WheelImage_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var pos = e.GetPosition(WheelImage);
+            PickColor(pos);
+        }
+
+        private void WheelImage_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                var pos = e.GetPosition(WheelImage);
+                PickColor(pos);
+            }
+        }
+
+        private void PickColor(Point pos)
+        {
+            double dx = pos.X - _center.X;
+            double dy = pos.Y - _center.Y;
+            double r = Math.Sqrt(dx * dx + dy * dy) / (_size / 2.0);
+            if (r > 1) return;
+            double angle = Math.Atan2(dy, dx);
+            double hue = (angle * 180 / Math.PI + 360) % 360;
+            SelectedColor = HsvToColor(hue, r, 1);
+            Canvas.SetLeft(Selector, pos.X - Selector.Width / 2);
+            Canvas.SetTop(Selector, pos.Y - Selector.Height / 2);
+            Selector.Visibility = Visibility.Visible;
+        }
+
+        private Color HsvToColor(double h, double s, double v)
+        {
+            double c = v * s;
+            double x = c * (1 - Math.Abs((h / 60) % 2 - 1));
+            double m = v - c;
+            double r1 = 0, g1 = 0, b1 = 0;
+            if (h < 60) { r1 = c; g1 = x; }
+            else if (h < 120) { r1 = x; g1 = c; }
+            else if (h < 180) { g1 = c; b1 = x; }
+            else if (h < 240) { g1 = x; b1 = c; }
+            else if (h < 300) { r1 = x; b1 = c; }
+            else { r1 = c; b1 = x; }
+            byte r = (byte)Math.Round((r1 + m) * 255);
+            byte g = (byte)Math.Round((g1 + m) * 255);
+            byte b = (byte)Math.Round((b1 + m) * 255);
+            return Color.FromRgb(r, g, b);
+        }
+    }
+}

--- a/PressPlay/Effects/ColorCorrectionEffect.cs
+++ b/PressPlay/Effects/ColorCorrectionEffect.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenCvSharp;
+using DrawingColor = System.Drawing.Color;
+using MediaColor = System.Windows.Media.Color;
+using System.Windows.Media;
+
+namespace PressPlay.Effects
+{
+    public class ColorCorrectionEffect : IEffect
+    {
+        public string Name => "Color Correction";
+
+        private MediaColor _tintColor = Colors.White;
+        private double _brightness = 0.0; // -100..100
+        private double _contrast = 1.0;   // 0..3
+        private double _gamma = 1.0;      // 0.1..5
+
+        public bool Enabled { get; set; } = true;
+
+        public MediaColor TintColor
+        {
+            get => _tintColor;
+            set
+            {
+                _tintColor = value;
+                UpdateParameter("TintColor", _tintColor);
+            }
+        }
+
+        public double Brightness
+        {
+            get => _brightness;
+            set
+            {
+                _brightness = value;
+                UpdateParameter("Brightness", _brightness);
+            }
+        }
+
+        public double Contrast
+        {
+            get => _contrast;
+            set
+            {
+                _contrast = value;
+                UpdateParameter("Contrast", _contrast);
+            }
+        }
+
+        public double Gamma
+        {
+            get => _gamma;
+            set
+            {
+                _gamma = value;
+                UpdateParameter("Gamma", _gamma);
+            }
+        }
+
+        public ObservableCollection<EffectParameter> Parameters { get; }
+
+        public ColorCorrectionEffect()
+        {
+            Parameters = new ObservableCollection<EffectParameter>
+            {
+                new EffectParameter("TintColor", _tintColor),
+                new EffectParameter("Brightness", _brightness, -100, 100),
+                new EffectParameter("Contrast", _contrast, 0, 3),
+                new EffectParameter("Gamma", _gamma, 0.1, 5)
+            };
+        }
+
+        public void ProcessFrame(Mat inputFrame, Mat outputFrame)
+        {
+            if (!Enabled)
+            {
+                inputFrame.CopyTo(outputFrame);
+                return;
+            }
+
+            inputFrame.CopyTo(outputFrame);
+
+            // brightness and contrast
+            outputFrame.ConvertTo(outputFrame, -1, _contrast, _brightness);
+
+            // gamma correction
+            if (Math.Abs(_gamma - 1.0) > 0.001)
+            {
+                byte[] lut = new byte[256];
+                double invGamma = 1.0 / _gamma;
+                for (int i = 0; i < 256; i++)
+                {
+                    lut[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, invGamma) * 255.0, 0, 255);
+                }
+                using var table = new Mat(1, 256, MatType.CV_8UC1, lut);
+                Cv2.LUT(outputFrame, table, outputFrame);
+            }
+
+            // color tint using saturation as strength
+            var drawingColor = DrawingColor.FromArgb(_tintColor.A, _tintColor.R, _tintColor.G, _tintColor.B);
+            double sat = drawingColor.GetSaturation();
+            if (sat > 0.001)
+            {
+                using var overlay = new Mat(outputFrame.Size(), outputFrame.Type(), new Scalar(_tintColor.B, _tintColor.G, _tintColor.R));
+                Cv2.AddWeighted(outputFrame, 1.0 - sat, overlay, sat, 0, outputFrame);
+            }
+        }
+
+        private void UpdateParameter(string name, object value)
+        {
+            var param = Parameters.FirstOrDefault(p => p.Name == name);
+            if (param != null)
+                param.Value = value;
+        }
+    }
+}

--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -499,6 +499,28 @@
                         </Grid>
                     </TabItem>
 
+                    <TabItem Header="Color Correction">
+                        <Grid>
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <StackPanel Margin="5">
+                                    <TextBlock Text="Select a clip to adjust its color" Foreground="LightGray"
+                                               Visibility="{Binding SelectedProjectClip, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=true}"
+                                               HorizontalAlignment="Center" Margin="0,20,0,0"/>
+
+                                    <StackPanel Visibility="{Binding SelectedProjectClip, Converter={StaticResource NullToVisibilityConverter}}">
+                                        <customcontrols:ColorWheel SelectedColor="{Binding ColorEffect.TintColor, Mode=TwoWay}" Margin="0,0,0,10"/>
+                                        <TextBlock Text="Brightness" Foreground="LightGray"/>
+                                        <Slider Minimum="-100" Maximum="100" Value="{Binding ColorEffect.Brightness, Mode=TwoWay}"/>
+                                        <TextBlock Text="Contrast" Foreground="LightGray" Margin="0,10,0,0"/>
+                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Contrast, Mode=TwoWay}"/>
+                                        <TextBlock Text="Gamma" Foreground="LightGray" Margin="0,10,0,0"/>
+                                        <Slider Minimum="0.1" Maximum="5" Value="{Binding ColorEffect.Gamma, Mode=TwoWay}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Grid>
+                    </TabItem>
+
                 </TabControl>
             </Grid>
 

--- a/PressPlay/Models/TrackItems.cs
+++ b/PressPlay/Models/TrackItems.cs
@@ -497,7 +497,7 @@ namespace PressPlay.Models
             set => SetField(ref _opacity, value);
         }
 
-        private bool _keyframesEnabled = true;
+        private bool _keyframesEnabled = false;
         [JsonInclude]
         public bool KeyframesEnabled
         {

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -271,6 +271,15 @@ namespace PressPlay.Serialization
                     Debug.WriteLine($"Restored BlendingEffect for clip {clip.FileName} - Mode={be.BlendMode}");
                 }
             }
+
+            var colorEffects = clip.Effects.OfType<ColorCorrectionEffect>().ToList();
+            if (colorEffects.Any())
+            {
+                foreach (var ce in colorEffects)
+                {
+                    Debug.WriteLine($"Restored ColorCorrectionEffect for clip {clip.FileName} - Brightness={ce.Brightness}, Contrast={ce.Contrast}, Gamma={ce.Gamma}");
+                }
+            }
         }
     }
 
@@ -392,6 +401,13 @@ namespace PressPlay.Serialization
 
                 if (root.TryGetProperty("Opacity", out var opacityElement))
                     ti.Opacity = opacityElement.GetDouble();
+
+                if (root.TryGetProperty("KeyframesEnabled", out var kfeElement))
+                    ti.KeyframesEnabled = kfeElement.GetBoolean();
+                else
+                    ti.KeyframesEnabled = root.TryGetProperty("Keyframes", out var kfeDict) &&
+                        JsonSerializer.Deserialize<Dictionary<string, ObservableCollection<Keyframe>>>(kfeDict.GetRawText(), options)?
+                        .Any(kv => kv.Value != null && kv.Value.Count > 0) == true;
 
                 // ---- New: Pivot / origin for scale and rotation ----
                 if (root.TryGetProperty("ScaleOrigin", out var so))
@@ -520,6 +536,7 @@ namespace PressPlay.Serialization
                 writer.WriteNumber("Y", ti.RotationOrigin.Y);
                 writer.WriteEndObject();
                 writer.WriteNumber("Volume", ti.Volume);
+                writer.WriteBoolean("KeyframesEnabled", ti.KeyframesEnabled);
 
                 // Serialize keyframe dictionary
                 writer.WritePropertyName("Keyframes");
@@ -639,6 +656,23 @@ namespace PressPlay.Serialization
                     be.BlendMode = Enum.Parse<BlendMode>(blendModeProp.GetString());
                 effect = be;
             }
+            else if (string.Equals(typeName, "Color Correction", StringComparison.OrdinalIgnoreCase))
+            {
+                var cc = new ColorCorrectionEffect();
+                if (root.TryGetProperty("TintColor", out var tintProp))
+                    cc.TintColor = DeserializeColor(tintProp);
+                if (root.TryGetProperty("Brightness", out var brProp))
+                    cc.Brightness = brProp.GetDouble();
+                if (root.TryGetProperty("Contrast", out var ctProp))
+                    cc.Contrast = ctProp.GetDouble();
+                if (root.TryGetProperty("Gamma", out var gmProp))
+                    cc.Gamma = gmProp.GetDouble();
+                if (root.TryGetProperty("Enabled", out var enProp))
+                    cc.Enabled = enProp.GetBoolean();
+                else
+                    cc.Enabled = true;
+                effect = cc;
+            }
             else
             {
                 Debug.WriteLine($"WARNING: Unknown effect type: {typeName}");
@@ -676,6 +710,15 @@ namespace PressPlay.Serialization
             else if (value is BlendingEffect be)
             {
                 writer.WriteString("BlendMode", be.BlendMode.ToString());
+            }
+            else if (value is ColorCorrectionEffect cc)
+            {
+                writer.WritePropertyName("TintColor");
+                WriteColor(writer, cc.TintColor);
+                writer.WriteNumber("Brightness", cc.Brightness);
+                writer.WriteNumber("Contrast", cc.Contrast);
+                writer.WriteNumber("Gamma", cc.Gamma);
+                writer.WriteBoolean("Enabled", cc.Enabled);
             }
 
             writer.WriteEndObject();

--- a/PressPlay/ViewModels/MainWindowViewModel.cs
+++ b/PressPlay/ViewModels/MainWindowViewModel.cs
@@ -74,10 +74,26 @@ namespace PressPlay
         private ITrackItem _selectedTrackItem;
 
         [NotifyPropertyChangedFor(nameof(HasClip))]
+        [NotifyPropertyChangedFor(nameof(ColorEffect))]
         [ObservableProperty]
         private ProjectClip _selectedProjectClip;
 
         public bool HasClip => SelectedProjectClip != null;
+
+        public ColorCorrectionEffect ColorEffect
+        {
+            get
+            {
+                if (SelectedProjectClip == null) return null;
+                var effect = SelectedProjectClip.Effects.OfType<ColorCorrectionEffect>().FirstOrDefault();
+                if (effect == null)
+                {
+                    effect = new ColorCorrectionEffect();
+                    SelectedProjectClip.Effects.Add(effect);
+                }
+                return effect;
+            }
+        }
 
 
         [ObservableProperty]


### PR DESCRIPTION
## Summary
- disable keyframes by default and persist selection in projects
- add color correction tab with color wheel and brightness/contrast/gamma controls
- implement OpenCV-based color correction effect and serialization

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7128df8788321915b5d87c170c200