### PR TITLE
Fix color tint blending

### DIFF
--- a/PressPlay.Tests/ColorCorrectionEffectTests.cs
+++ b/PressPlay.Tests/ColorCorrectionEffectTests.cs
@@ -1,0 +1,35 @@
+using OpenCvSharp;
+using PressPlay.Effects;
+using Xunit;
+
+namespace PressPlay.Tests;
+
+public class ColorCorrectionEffectTests
+{
+    [Fact]
+    public void TintColor_BlendsWithFrameInsteadOfOverlaying()
+    {
+        var effect = new ColorCorrectionEffect
+        {
+            TintColor = System.Windows.Media.Color.FromRgb(255, 0, 0)
+        };
+
+        using var input = new Mat(1, 2, MatType.CV_8UC3);
+        input.Set(0, 0, new Scalar(10, 20, 30));
+        input.Set(0, 1, new Scalar(40, 50, 60));
+
+        using var output = new Mat();
+        effect.ProcessFrame(input, output);
+
+        var pixel1 = output.Get<Vec3b>(0, 0);
+        var pixel2 = output.Get<Vec3b>(0, 1);
+
+        Assert.Equal(0, pixel1.Item0);
+        Assert.Equal(0, pixel1.Item1);
+        Assert.Equal(30, pixel1.Item2);
+
+        Assert.Equal(0, pixel2.Item0);
+        Assert.Equal(0, pixel2.Item1);
+        Assert.Equal(60, pixel2.Item2);
+    }
+}

--- a/PressPlay/Effects/ColorCorrectionEffect.cs
+++ b/PressPlay/Effects/ColorCorrectionEffect.cs
@@ -98,13 +98,19 @@ namespace PressPlay.Effects
                 Cv2.LUT(outputFrame, table, outputFrame);
             }
 
-            // color tint using saturation as strength
+            // color tint using saturation as strength. Instead of simply
+            // cross-fading to a solid color (which results in a flat overlay),
+            // multiply the frame with the tint color and blend the result. This
+            // preserves the luminance details of the original frame while
+            // shifting the hue toward the tint color.
             var drawingColor = DrawingColor.FromArgb(_tintColor.A, _tintColor.R, _tintColor.G, _tintColor.B);
             double sat = drawingColor.GetSaturation();
             if (sat > 0.001)
             {
-                using var overlay = new Mat(outputFrame.Size(), outputFrame.Type(), new Scalar(_tintColor.B, _tintColor.G, _tintColor.R));
-                Cv2.AddWeighted(outputFrame, 1.0 - sat, overlay, sat, 0, outputFrame);
+                using var colorMat = new Mat(outputFrame.Size(), outputFrame.Type(), new Scalar(_tintColor.B, _tintColor.G, _tintColor.R));
+                using var tinted = new Mat();
+                Cv2.Multiply(outputFrame, colorMat, tinted, 1.0 / 255.0);
+                Cv2.AddWeighted(outputFrame, 1.0 - sat, tinted, sat, 0, outputFrame);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure color tint blends with video instead of replacing it
- add regression test for color correction effect

## Testing
- `dotnet test` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7161c6cb883219ccab86ac552d3eb