### PR TITLE
Add saturation control and refine color correction

### DIFF
--- a/PressPlay.Tests/ColorCorrectionEffectTests.cs
+++ b/PressPlay.Tests/ColorCorrectionEffectTests.cs
@@ -32,4 +32,31 @@ public class ColorCorrectionEffectTests
         Assert.Equal(0, pixel2.Item1);
         Assert.Equal(60, pixel2.Item2);
     }
+
+    [Fact]
+    public void Gamma_GreaterThanOne_DarkensImage()
+    {
+        var effect = new ColorCorrectionEffect { Gamma = 2.0 };
+
+        using var input = new Mat(1, 1, MatType.CV_8UC3, new Scalar(128, 128, 128));
+        using var output = new Mat();
+        effect.ProcessFrame(input, output);
+
+        var pixel = output.Get<Vec3b>(0, 0);
+        Assert.True(pixel.Item0 < 128);
+    }
+
+    [Fact]
+    public void Saturation_Zero_ProducesGrayscale()
+    {
+        var effect = new ColorCorrectionEffect { Saturation = 0.0 };
+
+        using var input = new Mat(1, 1, MatType.CV_8UC3, new Scalar(10, 20, 30));
+        using var output = new Mat();
+        effect.ProcessFrame(input, output);
+
+        var pixel = output.Get<Vec3b>(0, 0);
+        Assert.Equal(pixel.Item0, pixel.Item1);
+        Assert.Equal(pixel.Item1, pixel.Item2);
+    }
 }

--- a/PressPlay/Effects/ColorCorrectionEffect.cs
+++ b/PressPlay/Effects/ColorCorrectionEffect.cs
@@ -16,6 +16,7 @@ namespace PressPlay.Effects
         private double _brightness = 0.0; // -100..100
         private double _contrast = 1.0;   // 0..3
         private double _gamma = 1.0;      // 0.1..5
+        private double _saturation = 1.0; // 0..3
 
         public bool Enabled { get; set; } = true;
 
@@ -59,6 +60,16 @@ namespace PressPlay.Effects
             }
         }
 
+        public double Saturation
+        {
+            get => _saturation;
+            set
+            {
+                _saturation = value;
+                UpdateParameter("Saturation", _saturation);
+            }
+        }
+
         public ObservableCollection<EffectParameter> Parameters { get; }
 
         public ColorCorrectionEffect()
@@ -68,7 +79,8 @@ namespace PressPlay.Effects
                 new EffectParameter("TintColor", _tintColor),
                 new EffectParameter("Brightness", _brightness, -100, 100),
                 new EffectParameter("Contrast", _contrast, 0, 3),
-                new EffectParameter("Gamma", _gamma, 0.1, 5)
+                new EffectParameter("Gamma", _gamma, 0.1, 5),
+                new EffectParameter("Saturation", _saturation, 0, 3)
             };
         }
 
@@ -89,13 +101,29 @@ namespace PressPlay.Effects
             if (Math.Abs(_gamma - 1.0) > 0.001)
             {
                 byte[] lut = new byte[256];
-                double invGamma = 1.0 / _gamma;
                 for (int i = 0; i < 256; i++)
                 {
-                    lut[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, invGamma) * 255.0, 0, 255);
+                    lut[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, _gamma) * 255.0, 0, 255);
                 }
                 using var lutIA = InputArray.Create(lut);
                 Cv2.LUT(outputFrame, lutIA, outputFrame);
+            }
+
+            // saturation adjustment
+            if (Math.Abs(_saturation - 1.0) > 0.001)
+            {
+                using var hsv = new Mat();
+                Cv2.CvtColor(outputFrame, hsv, ColorConversionCodes.BGR2HSV);
+                var channels = Cv2.Split(hsv);
+                channels[1].ConvertTo(channels[1], channels[1].Type(), _saturation, 0);
+                using (var maxMat = new Mat(channels[1].Size(), channels[1].Type(), new Scalar(255)))
+                {
+                    Cv2.Min(channels[1], maxMat, channels[1]);
+                }
+                Cv2.Merge(channels, hsv);
+                Cv2.CvtColor(hsv, outputFrame, ColorConversionCodes.HSV2BGR);
+                foreach (var ch in channels)
+                    ch.Dispose();
             }
 
             // color tint using saturation as strength. Instead of simply
@@ -104,13 +132,13 @@ namespace PressPlay.Effects
             // preserves the luminance details of the original frame while
             // shifting the hue toward the tint color.
             var drawingColor = DrawingColor.FromArgb(_tintColor.A, _tintColor.R, _tintColor.G, _tintColor.B);
-            double sat = drawingColor.GetSaturation();
-            if (sat > 0.001)
+            double tintSat = drawingColor.GetSaturation();
+            if (tintSat > 0.001)
             {
                 using var colorMat = new Mat(outputFrame.Size(), outputFrame.Type(), new Scalar(_tintColor.B, _tintColor.G, _tintColor.R));
                 using var tinted = new Mat();
                 Cv2.Multiply(outputFrame, colorMat, tinted, 1.0 / 255.0);
-                Cv2.AddWeighted(outputFrame, 1.0 - sat, tinted, sat, 0, outputFrame);
+                Cv2.AddWeighted(outputFrame, 1.0 - tintSat, tinted, tintSat, 0, outputFrame);
             }
         }
 

--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -510,11 +510,13 @@
                                     <StackPanel Visibility="{Binding SelectedProjectClip, Converter={StaticResource NullToVisibilityConverter}}">
                                         <customcontrols:ColorWheel SelectedColor="{Binding ColorEffect.TintColor, Mode=TwoWay}" Margin="0,0,0,10"/>
                                         <TextBlock Text="Brightness" Foreground="LightGray"/>
-                                        <Slider Minimum="-100" Maximum="100" Value="{Binding ColorEffect.Brightness, Mode=TwoWay}"/>
+                                        <Slider Minimum="-100" Maximum="100" Value="{Binding ColorEffect.Brightness, Mode=TwoWay}" Width="150" HorizontalAlignment="Left"/>
                                         <TextBlock Text="Contrast" Foreground="LightGray" Margin="0,10,0,0"/>
-                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Contrast, Mode=TwoWay}"/>
+                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Contrast, Mode=TwoWay}" Width="150" HorizontalAlignment="Left"/>
                                         <TextBlock Text="Gamma" Foreground="LightGray" Margin="0,10,0,0"/>
-                                        <Slider Minimum="0.1" Maximum="5" Value="{Binding ColorEffect.Gamma, Mode=TwoWay}"/>
+                                        <Slider Minimum="0.1" Maximum="5" Value="{Binding ColorEffect.Gamma, Mode=TwoWay}" Width="150" HorizontalAlignment="Left"/>
+                                        <TextBlock Text="Saturation" Foreground="LightGray" Margin="0,10,0,0"/>
+                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Saturation, Mode=TwoWay}" Width="150" HorizontalAlignment="Left"/>
                                     </StackPanel>
                                 </StackPanel>
                             </ScrollViewer>

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -277,7 +277,7 @@ namespace PressPlay.Serialization
             {
                 foreach (var ce in colorEffects)
                 {
-                    Debug.WriteLine($"Restored ColorCorrectionEffect for clip {clip.FileName} - Brightness={ce.Brightness}, Contrast={ce.Contrast}, Gamma={ce.Gamma}");
+                    Debug.WriteLine($"Restored ColorCorrectionEffect for clip {clip.FileName} - Brightness={ce.Brightness}, Contrast={ce.Contrast}, Gamma={ce.Gamma}, Saturation={ce.Saturation}");
                 }
             }
         }
@@ -667,6 +667,8 @@ namespace PressPlay.Serialization
                     cc.Contrast = ctProp.GetDouble();
                 if (root.TryGetProperty("Gamma", out var gmProp))
                     cc.Gamma = gmProp.GetDouble();
+                if (root.TryGetProperty("Saturation", out var satProp))
+                    cc.Saturation = satProp.GetDouble();
                 if (root.TryGetProperty("Enabled", out var enProp))
                     cc.Enabled = enProp.GetBoolean();
                 else
@@ -718,6 +720,7 @@ namespace PressPlay.Serialization
                 writer.WriteNumber("Brightness", cc.Brightness);
                 writer.WriteNumber("Contrast", cc.Contrast);
                 writer.WriteNumber("Gamma", cc.Gamma);
+                writer.WriteNumber("Saturation", cc.Saturation);
                 writer.WriteBoolean("Enabled", cc.Enabled);
             }
 


### PR DESCRIPTION
## Summary
- Fix gamma correction to properly adjust color palette instead of only brightening
- Add saturation parameter with UI slider and persistence support
- Shorten color correction sliders for a cleaner layout

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c717b610908321943412b1e59a3673