### PR TITLE
Serialize color correction effect

### DIFF
--- a/PressPlay.Tests/ProjectSerializationTests.cs
+++ b/PressPlay.Tests/ProjectSerializationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using PressPlay.Models;
 using PressPlay.Serialization;
+using PressPlay.Effects;
 using Xunit;
 
 namespace PressPlay.Tests;
@@ -57,5 +58,28 @@ public class ProjectSerializationTests
 
         loadedItem.EvaluateKeyframes(0);
         Assert.Equal(12.5, loadedItem.TranslateX);
+    }
+
+    [Fact]
+    public void ColorCorrectionEffect_IsSerializedWithSliderValues()
+    {
+        var project = new Project { FPS = 25 };
+        var clip = new ProjectClip();
+        clip.Effects.Add(new ColorCorrectionEffect
+        {
+            Brightness = 10,
+            Contrast = 1.5,
+            Saturation = 0.5
+        });
+        project.Clips.Add(clip);
+
+        var json = ProjectSerializer.SerializeProject(project);
+        var loaded = ProjectSerializer.DeserializeProject(json);
+
+        var loadedClip = Assert.Single(loaded.Clips);
+        var cc = Assert.IsType<ColorCorrectionEffect>(Assert.Single(loadedClip.Effects));
+        Assert.Equal(10, cc.Brightness);
+        Assert.Equal(1.5, cc.Contrast);
+        Assert.Equal(0.5, cc.Saturation);
     }
 }

--- a/PressPlay/Models/ProjectClip.cs
+++ b/PressPlay/Models/ProjectClip.cs
@@ -80,6 +80,7 @@ namespace PressPlay.Models
         public bool IsSelected { get => _isSelected; set { _isSelected = value; OnPropertyChanged(); } }
         public TimeCode Length { get => _length; set { _length = value; OnPropertyChanged(); } }
         public bool UnlimitedLength { get; private set; }
+        [JsonInclude]
         public ObservableCollection<IEffect> Effects { get; } = new ObservableCollection<IEffect>();
         [JsonInclude]
         public double FPS { get; private set; }


### PR DESCRIPTION
## Summary
- ensure project clips serialize their effects, allowing color correction data to persist
- cover color correction serialization with unit test

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71be1bb608321bd79420ce5998841