### PR TITLE
Preserve color correction effects in track items

### DIFF
--- a/PressPlay.Tests/ProjectSerializationTests.cs
+++ b/PressPlay.Tests/ProjectSerializationTests.cs
@@ -64,20 +64,36 @@ public class ProjectSerializationTests
     public void ColorCorrectionEffect_IsSerializedWithSliderValues()
     {
         var project = new Project { FPS = 25 };
-        var clip = new ProjectClip();
-        clip.Effects.Add(new ColorCorrectionEffect
+
+        // Create a clip and a track item referencing it
+        var clip = new ProjectClip { FilePath = "clip.mp4" };
+        project.Clips.Add(clip);
+
+        var track = new Track { Name = "V1" };
+        var item = new TrackItem
+        {
+            FilePath = "clip.mp4",
+            Start = new TimeCode(0, 25),
+            End = new TimeCode(10, 25),
+            OriginalEnd = new TimeCode(10, 25),
+            SourceLength = new TimeCode(10, 25)
+        };
+
+        item.Effects.Add(new ColorCorrectionEffect
         {
             Brightness = 10,
             Contrast = 1.5,
             Saturation = 0.5
         });
-        project.Clips.Add(clip);
+
+        track.Items.Add(item);
+        project.Tracks.Add(track);
 
         var json = ProjectSerializer.SerializeProject(project);
         var loaded = ProjectSerializer.DeserializeProject(json);
 
-        var loadedClip = Assert.Single(loaded.Clips);
-        var cc = Assert.IsType<ColorCorrectionEffect>(Assert.Single(loadedClip.Effects));
+        var loadedItem = Assert.IsType<TrackItem>(loaded.Tracks[0].Items[0]);
+        var cc = Assert.IsType<ColorCorrectionEffect>(Assert.Single(loadedItem.Effects));
         Assert.Equal(10, cc.Brightness);
         Assert.Equal(1.5, cc.Contrast);
         Assert.Equal(0.5, cc.Saturation);

--- a/PressPlay/Serialization/ProjectSerializer.cs
+++ b/PressPlay/Serialization/ProjectSerializer.cs
@@ -455,6 +455,24 @@ namespace PressPlay.Serialization
                         Debug.WriteLine($"Failed to deserialize keyframes: {ex.Message}");
                     }
                 }
+
+                // Deserialize additional track item effects (e.g. color correction)
+                if (root.TryGetProperty("Effects", out var effectsElement))
+                {
+                    try
+                    {
+                        var effects = JsonSerializer.Deserialize<ObservableCollection<IEffect>>(effectsElement.GetRawText(), options);
+                        if (effects != null)
+                        {
+                            foreach (var fx in effects)
+                                ti.Effects.Add(fx);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to deserialize effects: {ex.Message}");
+                    }
+                }
             }
 
             // Special handling for AudioTrackItem
@@ -541,6 +559,10 @@ namespace PressPlay.Serialization
                 // Serialize keyframe dictionary
                 writer.WritePropertyName("Keyframes");
                 JsonSerializer.Serialize(writer, ti.Keyframes, options);
+
+                // Serialize additional effects (e.g. color correction)
+                writer.WritePropertyName("Effects");
+                JsonSerializer.Serialize(writer, ti.Effects, options);
             }
 
             // Audio-specific properties


### PR DESCRIPTION
## Summary
- ensure track item effects collections are serialized and deserialized, including color correction sliders
- test that color correction brightness, contrast, and saturation round-trip through project save/load

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d84ceac8321a7b113b765e5d559