### PR TITLE
Add bound text boxes for color sliders

### DIFF
--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -510,11 +510,32 @@
                                     <StackPanel Visibility="{Binding SelectedProjectClip, Converter={StaticResource NullToVisibilityConverter}}">
                                         <customcontrols:ColorWheel SelectedColor="{Binding ColorEffect.TintColor, Mode=TwoWay}" Margin="0,0,0,10"/>
                                         <TextBlock Text="Brightness" Foreground="LightGray"/>
-                                        <Slider Minimum="-100" Maximum="100" Value="{Binding ColorEffect.Brightness, Mode=TwoWay}" Width="900" HorizontalAlignment="Left"/>
+                                        <Grid Width="900">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="50"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Slider Minimum="-100" Maximum="100" Value="{Binding ColorEffect.Brightness, Mode=TwoWay}" Grid.Column="0"/>
+                                            <TextBox Text="{Binding ColorEffect.Brightness, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Column="1" Margin="2" Width="50" Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                        </Grid>
                                         <TextBlock Text="Contrast" Foreground="LightGray" Margin="0,10,0,0"/>
-                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Contrast, Mode=TwoWay}" Width="900" HorizontalAlignment="Left"/>
+                                        <Grid Width="900">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="50"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Contrast, Mode=TwoWay}" Grid.Column="0"/>
+                                            <TextBox Text="{Binding ColorEffect.Contrast, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Grid.Column="1" Margin="2" Width="50" Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                        </Grid>
                                         <TextBlock Text="Saturation" Foreground="LightGray" Margin="0,10,0,0"/>
-                                        <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Saturation, Mode=TwoWay}" Width="900" HorizontalAlignment="Left"/>
+                                        <Grid Width="900">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="50"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Slider Minimum="0" Maximum="3" Value="{Binding ColorEffect.Saturation, Mode=TwoWay}" Grid.Column="0"/>
+                                            <TextBox Text="{Binding ColorEffect.Saturation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Grid.Column="1" Margin="2" Width="50" Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
+                                        </Grid>
                                     </StackPanel>
                                 </StackPanel>
                             </ScrollViewer>


### PR DESCRIPTION
## Summary
- Add grid-wrapped sliders for brightness, contrast, and saturation
- Introduce styled numeric text boxes bound to each color property with live updates

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet run --project PressPlay/PressPlay.csproj` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e983bbd88321af4cecc0d4091c5d