### PR TITLE
Implement property change notifications for color correction

### DIFF
--- a/PressPlay/Effects/ColorCorrectionEffect.cs
+++ b/PressPlay/Effects/ColorCorrectionEffect.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using OpenCvSharp;
 using DrawingColor = System.Drawing.Color;
@@ -8,7 +9,7 @@ using System.Windows.Media;
 
 namespace PressPlay.Effects
 {
-    public class ColorCorrectionEffect : IEffect
+    public class ColorCorrectionEffect : IEffect, INotifyPropertyChanged
     {
         public string Name => "Color Correction";
 
@@ -17,16 +18,38 @@ namespace PressPlay.Effects
         private double _contrast = 1.0;   // 0..3
         private double _gamma = 1.0;      // 0.1..5
         private double _saturation = 1.0; // 0..3
+        private bool _enabled = true;
 
-        public bool Enabled { get; set; } = true;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        public bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (_enabled != value)
+                {
+                    _enabled = value;
+                    UpdateParameter("Enabled", _enabled);
+                    OnPropertyChanged(nameof(Enabled));
+                }
+            }
+        }
 
         public MediaColor TintColor
         {
             get => _tintColor;
             set
             {
-                _tintColor = value;
-                UpdateParameter("TintColor", _tintColor);
+                if (_tintColor != value)
+                {
+                    _tintColor = value;
+                    UpdateParameter("TintColor", _tintColor);
+                    OnPropertyChanged(nameof(TintColor));
+                }
             }
         }
 
@@ -35,8 +58,12 @@ namespace PressPlay.Effects
             get => _brightness;
             set
             {
-                _brightness = value;
-                UpdateParameter("Brightness", _brightness);
+                if (Math.Abs(_brightness - value) > 0.0001)
+                {
+                    _brightness = value;
+                    UpdateParameter("Brightness", _brightness);
+                    OnPropertyChanged(nameof(Brightness));
+                }
             }
         }
 
@@ -45,8 +72,12 @@ namespace PressPlay.Effects
             get => _contrast;
             set
             {
-                _contrast = value;
-                UpdateParameter("Contrast", _contrast);
+                if (Math.Abs(_contrast - value) > 0.0001)
+                {
+                    _contrast = value;
+                    UpdateParameter("Contrast", _contrast);
+                    OnPropertyChanged(nameof(Contrast));
+                }
             }
         }
 
@@ -55,8 +86,12 @@ namespace PressPlay.Effects
             get => _gamma;
             set
             {
-                _gamma = value;
-                UpdateParameter("Gamma", _gamma);
+                if (Math.Abs(_gamma - value) > 0.0001)
+                {
+                    _gamma = value;
+                    UpdateParameter("Gamma", _gamma);
+                    OnPropertyChanged(nameof(Gamma));
+                }
             }
         }
 
@@ -65,8 +100,12 @@ namespace PressPlay.Effects
             get => _saturation;
             set
             {
-                _saturation = value;
-                UpdateParameter("Saturation", _saturation);
+                if (Math.Abs(_saturation - value) > 0.0001)
+                {
+                    _saturation = value;
+                    UpdateParameter("Saturation", _saturation);
+                    OnPropertyChanged(nameof(Saturation));
+                }
             }
         }
 

--- a/PressPlay/ViewModels/MainWindowViewModel.cs
+++ b/PressPlay/ViewModels/MainWindowViewModel.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Windows;
+using System.ComponentModel;
 using PressPlay.Serialization;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -78,6 +79,8 @@ namespace PressPlay
         [ObservableProperty]
         private ProjectClip _selectedProjectClip;
 
+        private ColorCorrectionEffect _currentColorEffect;
+
         public bool HasClip => SelectedProjectClip != null;
 
         public ColorCorrectionEffect ColorEffect
@@ -91,8 +94,33 @@ namespace PressPlay
                     effect = new ColorCorrectionEffect();
                     SelectedProjectClip.Effects.Add(effect);
                 }
+
+                if (_currentColorEffect != effect)
+                {
+                    if (_currentColorEffect != null)
+                        _currentColorEffect.PropertyChanged -= ColorEffect_PropertyChanged;
+                    _currentColorEffect = effect;
+                    _currentColorEffect.PropertyChanged += ColorEffect_PropertyChanged;
+                }
+
                 return effect;
             }
+        }
+
+        partial void OnSelectedProjectClipChanged(ProjectClip value)
+        {
+            if (_currentColorEffect != null)
+                _currentColorEffect.PropertyChanged -= ColorEffect_PropertyChanged;
+
+            _currentColorEffect = value?.Effects.OfType<ColorCorrectionEffect>().FirstOrDefault();
+
+            if (_currentColorEffect != null)
+                _currentColorEffect.PropertyChanged += ColorEffect_PropertyChanged;
+        }
+
+        private void ColorEffect_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            HasUnsavedChanges = true;
         }
 
 


### PR DESCRIPTION
## Summary
- implement INotifyPropertyChanged in ColorCorrectionEffect and raise PropertyChanged for each setter
- subscribe MainWindowViewModel to ColorCorrectionEffect changes to mark project dirty

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eaf843fc8321bbe4a5ba95a35287