### PR TITLE
Fix missing keyframe transforms in exports

### DIFF
--- a/PressPlay.Tests/ExportKeyframeTests.cs
+++ b/PressPlay.Tests/ExportKeyframeTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Drawing;
+using Xunit;
+using PressPlay.Export;
+using PressPlay.Models;
+
+namespace PressPlay.Tests
+{
+    public class ExportKeyframeTests
+    {
+        [Fact]
+        public void RenderFrame_UpdatesTransformFromKeyframes()
+        {
+            // Create temporary image file used by the clip
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var imgPath = Path.Combine(tempDir, "img.png");
+
+            using (var bmp = new Bitmap(2, 2))
+            {
+                bmp.SetPixel(0, 0, Color.White);
+                bmp.Save(imgPath, System.Drawing.Imaging.ImageFormat.Png);
+            }
+
+            // Build a minimal project with one track and one item
+            var project = new Project();
+            project.SetProjectResolution(100, 100);
+
+            var clip = new ProjectClip(imgPath) { TrackType = TimelineTrackType.Video, ItemType = TrackItemType.Image, FPS = 25 };
+            clip.Length = new TimeCode(20, 25);
+            project.Clips.Add(clip);
+
+            var track = new Track { Type = TimelineTrackType.Video };
+            var item = new TrackItem
+            {
+                FilePath = imgPath,
+                Position = new TimeCode(0, 25),
+                Start = new TimeCode(0, 25),
+                End = new TimeCode(20, 25),
+                OriginalEnd = new TimeCode(20, 25),
+                KeyframesEnabled = true
+            };
+
+            item.TranslateXKeyframes.Add(new Keyframe { Frame = 0, Value = 0, Interpolation = "Linear" });
+            item.TranslateXKeyframes.Add(new Keyframe { Frame = 10, Value = 100, Interpolation = "Linear" });
+
+            track.Items.Add(item);
+            project.Tracks.Add(track);
+
+            var exportService = new ExportService(project);
+
+            // Invoke the private RenderFrame method via reflection at frame 5
+            var method = typeof(ExportService).GetMethod("RenderFrame", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var bmpResult = method.Invoke(exportService, new object[] { new TimeCode(5, 25), 100, 100 }) as Bitmap;
+            bmpResult?.Dispose();
+
+            // After rendering, the item's TranslateX should reflect interpolated keyframe value
+            Assert.Equal(50, item.TranslateX);
+        }
+    }
+}
+

--- a/PressPlay/Export/ExportService.cs
+++ b/PressPlay/Export/ExportService.cs
@@ -296,6 +296,10 @@ namespace PressPlay.Export
                     // Draw each item
                     foreach (var item in activeItems)
                     {
+                        // Update transform properties from keyframes before drawing
+                        if (item is TrackItem ti)
+                            ti.EvaluateKeyframes(idx);
+
                         DrawItemWithFade(item, idx, width, height, drawingContext);
                     }
                 }


### PR DESCRIPTION
## Summary
- apply keyframe evaluation before drawing items during export
- add regression test validating keyframe-driven transforms during export

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eff08c1483218d0e7a20453811e5