### PR TITLE
Prevent unintended keyframe creation when selecting clips

### DIFF
--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -250,13 +250,32 @@ namespace PressPlay.Timeline
             if (sender is ItemsControl strip && DataContext is TrackItem item)
             {
                 if (!item.KeyframesEnabled) return;
+
                 _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
                 var project = _timelineControl?.Project;
                 if (project == null || project.IsPlaying) return;
 
+                if (e.OriginalSource is not DependencyObject originalSource)
+                {
+                    return;
+                }
+
+                var originatingStrip = VisualHelper.GetAncestor<ItemsControl>(originalSource);
+                if (!ReferenceEquals(originatingStrip, strip) && !ReferenceEquals(originalSource, strip))
+                {
+                    return;
+                }
+
+                var position = e.GetPosition(strip);
+                if (position.X < 0 || position.X > strip.ActualWidth ||
+                    position.Y < 0 || position.Y > strip.ActualHeight)
+                {
+                    return;
+                }
+
                 if (e.OriginalSource is Canvas)
                 {
-                    double x = e.GetPosition(strip).X;
+                    double x = position.X;
                     int frame = item.Position.TotalFrames + Constants.PixelsToFrames(x, project.TimelineZoom);
                     string property = strip.Tag as string ?? string.Empty;
                     if (!item.Keyframes.TryGetValue(property, out var list)) return;


### PR DESCRIPTION
## Summary
- ensure keyframe strips only react to clicks that originate within the strip itself
- ignore mouse events that occur outside of the strip bounds to avoid accidental keyframe creation

## Testing
- `dotnet build PressPlay.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4fdc150c8321b3ea755f7ae51249