### PR TITLE
Prevent keyframes from auto-adding on clip selection

### DIFF
--- a/PressPlay/MainWindow.xaml
+++ b/PressPlay/MainWindow.xaml
@@ -349,7 +349,15 @@
                                                     </Grid.ColumnDefinitions>
                                                     <Slider Value="{Binding SelectedTrackItem.Opacity, Mode=TwoWay}"
                                         Minimum="0" Maximum="1" Grid.Column="0" Margin="2"
-                                        Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Opacity" ValueChanged="PropertySlider_ValueChanged"/>
+                                        Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Opacity"
+                                        ValueChanged="PropertySlider_ValueChanged"
+                                        PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                        PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                        PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                        PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                        PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                        LostMouseCapture="PropertySlider_LostMouseCapture"
+                                        LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                                     <TextBox Text="{Binding SelectedTrackItem.Opacity, StringFormat=P0, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
                                                 </Grid>
@@ -431,7 +439,14 @@
                                                             <ColumnDefinition Width="*"/>
                                                             <ColumnDefinition Width="50"/>
                                                         </Grid.ColumnDefinitions>
-                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}" Minimum="0" Maximum="360" Grid.Column="0" Margin="2" Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"/>
+                                                        <Slider Value="{Binding SelectedTrackItem.Rotation, Mode=TwoWay}" Minimum="0" Maximum="360" Grid.Column="0" Margin="2" Background="#FF3A3A3A" BorderBrush="#FF4A4A4A" Tag="Rotation" ValueChanged="PropertySlider_ValueChanged"
+                                                                PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                                                PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                                                PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                                                PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                                                PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                                                LostMouseCapture="PropertySlider_LostMouseCapture"
+                                                                LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                                         <TextBox Text="{Binding SelectedTrackItem.Rotation, StringFormat=0.0°, Mode=TwoWay}" Grid.Column="1" Margin="2"
                                          Background="#FF3A3A3A" Foreground="LightGray" BorderBrush="#FF4A4A4A"/>
                                                     </Grid>
@@ -443,13 +458,41 @@
                                                 </Grid>
                                                 <!-- Sliders with labels -->
                                                 <TextBlock Text="Transform X" Foreground="LightGray" Margin="0,10,0,0"/>
-                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateX, Mode=TwoWay}" Tag="TranslateX" ValueChanged="PropertySlider_ValueChanged"
+                                                        PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                                        PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                                        PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                                        PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                                        PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                                        LostMouseCapture="PropertySlider_LostMouseCapture"
+                                                        LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                                 <TextBlock Text="Transform Y" Foreground="LightGray"/>
-                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="-500" Maximum="500" Value="{Binding SelectedTrackItem.TranslateY, Mode=TwoWay}" Tag="TranslateY" ValueChanged="PropertySlider_ValueChanged"
+                                                        PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                                        PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                                        PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                                        PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                                        PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                                        LostMouseCapture="PropertySlider_LostMouseCapture"
+                                                        LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                                 <TextBlock Text="Scale X" Foreground="LightGray" Margin="0,10,0,0"/>
-                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleX, Mode=TwoWay}" Tag="ScaleX" ValueChanged="PropertySlider_ValueChanged"
+                                                        PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                                        PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                                        PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                                        PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                                        PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                                        LostMouseCapture="PropertySlider_LostMouseCapture"
+                                                        LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                                 <TextBlock Text="Scale Y" Foreground="LightGray"/>
-                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"/>
+                                                <Slider Minimum="0.1" Maximum="5" Value="{Binding SelectedTrackItem.ScaleY, Mode=TwoWay}" Tag="ScaleY" ValueChanged="PropertySlider_ValueChanged"
+                                                        PreviewMouseLeftButtonDown="PropertySlider_PreviewMouseLeftButtonDown"
+                                                        PreviewMouseLeftButtonUp="PropertySlider_PreviewMouseLeftButtonUp"
+                                                        PreviewMouseWheel="PropertySlider_PreviewMouseWheel"
+                                                        PreviewKeyDown="PropertySlider_PreviewKeyDown"
+                                                        PreviewKeyUp="PropertySlider_PreviewKeyUp"
+                                                        LostMouseCapture="PropertySlider_LostMouseCapture"
+                                                        LostKeyboardFocus="PropertySlider_LostKeyboardFocus"/>
                                             </StackPanel>
                                         </Expander>
 

--- a/PressPlay/MainWindow.xaml.cs
+++ b/PressPlay/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using PressPlay.Models;
 using PressPlay.Services;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;                  // ← for File.Exists
@@ -8,6 +9,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using PressPlayTitler;
 using PressPlay.Helpers;
 using CommunityToolkit.Mvvm.Input;
@@ -18,6 +20,16 @@ namespace PressPlay
     public partial class MainWindow : Window
     {
         private readonly IPlaybackService _playbackService;
+        private readonly HashSet<Slider> _activePropertySliderInteractions = new();
+        private static readonly HashSet<string> _keyframeSliderProperties = new(new[]
+        {
+            nameof(TrackItem.Opacity),
+            nameof(TrackItem.Rotation),
+            nameof(TrackItem.TranslateX),
+            nameof(TrackItem.TranslateY),
+            nameof(TrackItem.ScaleX),
+            nameof(TrackItem.ScaleY),
+        });
 
         public MainWindow()
         {
@@ -240,12 +252,98 @@ namespace PressPlay
             item.NotifyKeyframeChange(property);
         }
 
+        private static bool IsKeyframePropertySlider(Slider slider)
+        {
+            return slider.Tag is string property && _keyframeSliderProperties.Contains(property);
+        }
+
+        private void BeginPropertySliderInteraction(Slider slider)
+        {
+            if (IsKeyframePropertySlider(slider))
+            {
+                _activePropertySliderInteractions.Add(slider);
+            }
+        }
+
+        private void EndPropertySliderInteraction(Slider slider)
+        {
+            if (IsKeyframePropertySlider(slider))
+            {
+                _activePropertySliderInteractions.Remove(slider);
+            }
+        }
+
+        private void PropertySlider_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                BeginPropertySliderInteraction(slider);
+            }
+        }
+
+        private void PropertySlider_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                EndPropertySliderInteraction(slider);
+            }
+        }
+
+        private void PropertySlider_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                BeginPropertySliderInteraction(slider);
+                Dispatcher.BeginInvoke(new Action(() => EndPropertySliderInteraction(slider)), DispatcherPriority.Background);
+            }
+        }
+
+        private void PropertySlider_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                BeginPropertySliderInteraction(slider);
+            }
+        }
+
+        private void PropertySlider_PreviewKeyUp(object sender, KeyEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                EndPropertySliderInteraction(slider);
+            }
+        }
+
+        private void PropertySlider_LostMouseCapture(object sender, MouseEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                EndPropertySliderInteraction(slider);
+            }
+        }
+
+        private void PropertySlider_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            if (sender is Slider slider)
+            {
+                EndPropertySliderInteraction(slider);
+            }
+        }
+
         private void PropertySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (DataContext is not MainWindowViewModel vm) return;
             if (vm.CurrentProject.IsPlaying) return;
             if (vm.SelectedTrackItem is not TrackItem item) return;
             if (sender is not Slider slider || slider.Tag is not string property) return;
+
+            if (!IsKeyframePropertySlider(slider)) return;
+
+            bool userInitiated = _activePropertySliderInteractions.Contains(slider) || slider.IsMouseCaptureWithin;
+            if (!userInitiated)
+            {
+                return;
+            }
 
             if (!item.KeyframesEnabled) return;
 

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -250,22 +250,35 @@ namespace PressPlay.Timeline
             if (sender is ItemsControl strip && DataContext is TrackItem item)
             {
                 if (!item.KeyframesEnabled) return;
+
                 _timelineControl ??= VisualHelper.GetAncestor<TimelineControl>(this);
                 var project = _timelineControl?.Project;
                 if (project == null || project.IsPlaying) return;
 
+                if (e.OriginalSource is not DependencyObject originalSource)
+                {
+                    return;
+                }
+
+                var originatingStrip = VisualHelper.GetAncestor<ItemsControl>(originalSource);
+                if (!ReferenceEquals(originatingStrip, strip) && !ReferenceEquals(originalSource, strip))
+                {
+                    return;
+                }
+
+                var position = e.GetPosition(strip);
+                if (position.X < 0 || position.X > strip.ActualWidth ||
+                    position.Y < 0 || position.Y > strip.ActualHeight)
+                {
+                    return;
+                }
+
                 if (e.OriginalSource is Canvas)
                 {
-                    double x = e.GetPosition(strip).X;
-                    int frame = item.Position.TotalFrames + Constants.PixelsToFrames(x, project.TimelineZoom);
-                    string property = strip.Tag as string ?? string.Empty;
-                    if (!item.Keyframes.TryGetValue(property, out var list)) return;
-                    if (!list.Any(k => k.Frame == frame))
-                    {
-                        double value = item.GetAnimated(property, frame);
-                        list.Add(new Keyframe { Frame = frame, Value = value });
-                        RefreshKeyframeStrip(property);
-                    }
+                    // Clicking on a keyframe strip should no longer create keyframes.
+                    // Keyframes are now created exclusively through slider interaction
+                    // (see PropertySlider_ValueChanged) so simply exit here.
+                    return;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure property keyframes are only generated when a user adjusts a property slider
- wire property sliders to track mouse, keyboard, and scroll interactions so programmatic updates are ignored
- disable empty keyframe strip clicks from creating new keyframes

## Testing
- `dotnet build PressPlay.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4fdc150c8321b3ea755f7ae51249