### PR TITLE
Sync keyframes with clip movement and improve selection

### DIFF
--- a/PressPlay/Models/Keyframe.cs
+++ b/PressPlay/Models/Keyframe.cs
@@ -1,10 +1,72 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
 namespace PressPlay.Models
 {
-    public class Keyframe
+    public class Keyframe : INotifyPropertyChanged
     {
-        public int Frame { get; set; }
-        public double Value { get; set; }
-        public string Interpolation { get; set; } = "Linear";
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private int _frame;
+        public int Frame
+        {
+            get => _frame;
+            set
+            {
+                if (_frame != value)
+                {
+                    _frame = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private double _value;
+        public double Value
+        {
+            get => _value;
+            set
+            {
+                if (!value.Equals(_value))
+                {
+                    _value = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _interpolation = "Linear";
+        public string Interpolation
+        {
+            get => _interpolation;
+            set
+            {
+                if (_interpolation != value)
+                {
+                    _interpolation = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected != value)
+                {
+                    _isSelected = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }
 

--- a/PressPlay/Models/Project.cs
+++ b/PressPlay/Models/Project.cs
@@ -189,6 +189,10 @@ namespace PressPlay.Models
             resizeData.NewPosition = item.Position;
             resizeData.NewStart = item.Start;
             resizeData.NewEnd = item.End;
+            if (item is TrackItem updatedTrackItem)
+            {
+                resizeData.SetNewKeyframeFrames(updatedTrackItem);
+            }
 
             multiUndo.UndoUnits.Add(new TrackItemResizeUndoUnit(resizeData));
 

--- a/PressPlay/Timeline/TimelineControl.xaml.cs
+++ b/PressPlay/Timeline/TimelineControl.xaml.cs
@@ -4,6 +4,7 @@ using PressPlay.Helpers;
 using PressPlay.Undo;
 using PressPlay.Undo.UndoUnits;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -36,6 +37,7 @@ namespace PressPlay.Timeline
         private TimeCode _mouseDownTrackItemEnd;
         private bool _resizingLeft;
         private bool _resizingRight;
+        private Dictionary<Keyframe, int>? _mouseDownKeyframeFrames;
 
         public Project Project
         {
@@ -203,6 +205,18 @@ namespace PressPlay.Timeline
                 _mouseDownTrackItemPosition = item.Position;
                 _mouseDownTrackItemStart = item.Start;
                 _mouseDownTrackItemEnd = item.End;
+                _mouseDownKeyframeFrames = null;
+                if (item is TrackItem trackItem && trackItem.KeyframesEnabled)
+                {
+                    _mouseDownKeyframeFrames = new Dictionary<Keyframe, int>();
+                    foreach (var collection in trackItem.Keyframes.Values)
+                    {
+                        foreach (var keyframe in collection)
+                        {
+                            _mouseDownKeyframeFrames[keyframe] = keyframe.Frame;
+                        }
+                    }
+                }
 
                 if (Project.SelectedTool == TimelineSelectedTool.SelectionTool)
                 {
@@ -230,6 +244,7 @@ namespace PressPlay.Timeline
                 _mouseDownTrackItemEnd = ti.End;
                 _mouseDownFadeControl = fadeControl;
                 _mouseDownElement = VisualHelper.GetAncestor<TrackItemControl>(fadeControl);
+                _mouseDownKeyframeFrames = null;
             }
             else
             {
@@ -271,6 +286,11 @@ namespace PressPlay.Timeline
                 var multi = new MultipleUndoUnits();
                 multi.UndoUnits.Add(new TrackItemResizeUndoUnit(data));
 
+                if (_mouseDownTrackItem is TrackItem trackItemWithKeyframes)
+                {
+                    data.SetNewKeyframeFrames(trackItemWithKeyframes);
+                }
+
                 if (_mouseDownTrack != _mouseUpTrack)
                 {
                     var rem = new TrackItemRemoveUndoUnit();
@@ -305,6 +325,7 @@ namespace PressPlay.Timeline
             _resizingLeft = false;
             _resizingRight = false;
             _tracksCanvasLeftMouseButtonDown = false;
+            _mouseDownKeyframeFrames = null;
         }
         private Track GetTrackAtPosition(Point position)
         {
@@ -374,6 +395,29 @@ namespace PressPlay.Timeline
 
                 // Update track item position
                 _mouseDownTrackItem.Position = new TimeCode(newPositionFrames, Project.FPS);
+
+                if (_mouseDownKeyframeFrames != null && _mouseDownTrackItem is TrackItem trackItem)
+                {
+                    int frameOffset = newPositionFrames - _mouseDownTrackItemPosition.TotalFrames;
+                    if (frameOffset != 0)
+                    {
+                        foreach (var collection in trackItem.Keyframes.Values)
+                        {
+                            foreach (var keyframe in collection)
+                            {
+                                if (_mouseDownKeyframeFrames.TryGetValue(keyframe, out int originalFrame))
+                                {
+                                    int newFrame = originalFrame + frameOffset;
+                                    if (newFrame < 0)
+                                    {
+                                        newFrame = 0;
+                                    }
+                                    keyframe.Frame = newFrame;
+                                }
+                            }
+                        }
+                    }
+                }
 
                 var originTrack = Project.Tracks.First(t => t.Items.Contains(_mouseDownTrackItem));
                 var mousePosition = e.GetPosition(tracksControl.Parent as IInputElement);

--- a/PressPlay/Timeline/TrackItemControl.xaml
+++ b/PressPlay/Timeline/TrackItemControl.xaml
@@ -183,6 +183,19 @@
                 <Style TargetType="ItemsControl">
                     <Setter Property="Width" Value="{Binding ElementName=itemControl, Path=ActualWidth}"/>
                 </Style>
+                <Style x:Key="KeyframeRectangleStyle" TargetType="Rectangle">
+                    <Setter Property="Width" Value="8"/>
+                    <Setter Property="Height" Value="8"/>
+                    <Setter Property="Stroke" Value="Black"/>
+                    <Setter Property="StrokeThickness" Value="1"/>
+                    <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                            <Setter Property="Fill" Value="#FFFFF176"/>
+                            <Setter Property="Stroke" Value="White"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
             </StackPanel.Resources>
             <ItemsControl x:Name="translateXStrip" Height="10" Tag="TranslateX" ItemsSource="{Binding TranslateXKeyframes}" Background="Transparent" MouseLeftButtonDown="KeyframeStrip_MouseLeftButtonDown" ToolTip="Position X">
                 <ItemsControl.ItemsPanel>
@@ -203,11 +216,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Red" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Red"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>
@@ -234,11 +251,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Orange" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Orange"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>
@@ -265,11 +286,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Yellow" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Yellow"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>
@@ -296,11 +321,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Green" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Green"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>
@@ -327,11 +356,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Blue" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Blue"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>
@@ -358,11 +391,15 @@
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Rectangle Width="8" Height="8" Fill="Purple" Stroke="Black" RenderTransformOrigin="0.5,0.5"
-                                   MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
+                        <Rectangle MouseLeftButtonDown="Keyframe_MouseLeftButtonDown"
                                    MouseMove="Keyframe_MouseMove"
                                    MouseLeftButtonUp="Keyframe_MouseLeftButtonUp"
                                    MouseRightButtonDown="Keyframe_MouseRightButtonDown">
+                            <Rectangle.Style>
+                                <Style TargetType="Rectangle" BasedOn="{StaticResource KeyframeRectangleStyle}">
+                                    <Setter Property="Fill" Value="Purple"/>
+                                </Style>
+                            </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <RotateTransform Angle="45"/>
                             </Rectangle.RenderTransform>

--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -21,6 +21,9 @@ namespace PressPlay.Timeline
         private Point _startPoint;
         private Keyframe? _draggingKeyframe;
         private ItemsControl? _draggingStrip;
+        private bool _keyframeToggleOnClick;
+        private bool _keyframeDragInitiated;
+        private Point _keyframeMouseDownPoint;
 
         public TrackItemControl()
         {
@@ -289,6 +292,23 @@ namespace PressPlay.Timeline
             {
                 _draggingKeyframe = kf;
                 _draggingStrip = GetParentItemsControl(fe);
+                _keyframeDragInitiated = false;
+                _keyframeToggleOnClick = kf.IsSelected;
+                if (_draggingStrip != null)
+                {
+                    _keyframeMouseDownPoint = e.GetPosition(_draggingStrip);
+                }
+                else
+                {
+                    _keyframeMouseDownPoint = e.GetPosition(fe);
+                }
+
+                if (!kf.IsSelected)
+                {
+                    kf.IsSelected = true;
+                    _keyframeToggleOnClick = false;
+                }
+
                 fe.CaptureMouse();
                 e.Handled = true;
             }
@@ -302,8 +322,24 @@ namespace PressPlay.Timeline
                 var project = _timelineControl?.Project;
                 if (project == null) return;
 
-                double x = e.GetPosition(_draggingStrip).X;
-                int frame = item.Position.TotalFrames + Constants.PixelsToFrames(x, project.TimelineZoom);
+                var position = e.GetPosition(_draggingStrip);
+
+                if (!_keyframeDragInitiated)
+                {
+                    if (Math.Abs(position.X - _keyframeMouseDownPoint.X) > SystemParameters.MinimumHorizontalDragDistance ||
+                        Math.Abs(position.Y - _keyframeMouseDownPoint.Y) > SystemParameters.MinimumVerticalDragDistance)
+                    {
+                        _keyframeDragInitiated = true;
+                        _keyframeToggleOnClick = false;
+                    }
+                }
+
+                double pixelsPerFrame = Constants.GetPixelsPerFrame(project.TimelineZoom);
+                int relativeFrames = (int)Math.Round(position.X / pixelsPerFrame, MidpointRounding.AwayFromZero);
+                int frame = item.Position.TotalFrames + relativeFrames;
+                int clipStartFrame = item.Position.TotalFrames;
+                int clipEndFrame = clipStartFrame + item.Duration.TotalFrames;
+                frame = Math.Max(clipStartFrame, Math.Min(clipEndFrame, frame));
                 _draggingKeyframe.Frame = frame;
                 RefreshKeyframeStrip(_draggingStrip.Tag as string ?? string.Empty);
             }
@@ -313,8 +349,14 @@ namespace PressPlay.Timeline
         {
             if (sender is FrameworkElement fe)
                 fe.ReleaseMouseCapture();
+            if (_draggingKeyframe != null && _keyframeToggleOnClick)
+            {
+                _draggingKeyframe.IsSelected = false;
+            }
             _draggingKeyframe = null;
             _draggingStrip = null;
+            _keyframeToggleOnClick = false;
+            _keyframeDragInitiated = false;
         }
 
         private void Keyframe_MouseRightButtonDown(object sender, MouseButtonEventArgs e)

--- a/PressPlay/Undo/UndoUnits/TrackItemResizeData.cs
+++ b/PressPlay/Undo/UndoUnits/TrackItemResizeData.cs
@@ -1,4 +1,5 @@
-﻿using PressPlay.Models;
+using PressPlay.Models;
+using System.Collections.Generic;
 
 namespace PressPlay.Undo.UndoUnits
 {
@@ -17,6 +18,10 @@ namespace PressPlay.Undo.UndoUnits
         public TimeCode OldPosition { get; set; }
 
         public TimeCode NewPosition { get; set; }
+
+        public Dictionary<Keyframe, int> OldKeyframeFrames { get; } = new();
+
+        public Dictionary<Keyframe, int> NewKeyframeFrames { get; } = new();
 
         public TrackItemResizeData()
         {
@@ -38,6 +43,12 @@ namespace PressPlay.Undo.UndoUnits
             NewPosition = item.Position;
             NewStart = item.Start;
             NewEnd = item.End;
+
+            if (item is TrackItem trackItem)
+            {
+                CaptureKeyframeFrames(trackItem, OldKeyframeFrames);
+                CaptureKeyframeFrames(trackItem, NewKeyframeFrames);
+            }
         }
 
         public void Undo()
@@ -45,6 +56,11 @@ namespace PressPlay.Undo.UndoUnits
             Item.Start = OldStart;
             Item.End = OldEnd;
             Item.Position = OldPosition;
+
+            if (Item is TrackItem trackItem)
+            {
+                ApplyKeyframeFrames(trackItem, OldKeyframeFrames);
+            }
         }
 
         public void Redo()
@@ -52,6 +68,47 @@ namespace PressPlay.Undo.UndoUnits
             Item.Start = NewStart;
             Item.End = NewEnd;
             Item.Position = NewPosition;
+
+            if (Item is TrackItem trackItem)
+            {
+                ApplyKeyframeFrames(trackItem, NewKeyframeFrames);
+            }
+        }
+
+        public void SetNewKeyframeFrames(TrackItem trackItem)
+        {
+            CaptureKeyframeFrames(trackItem, NewKeyframeFrames);
+        }
+
+        private static void CaptureKeyframeFrames(TrackItem trackItem, Dictionary<Keyframe, int> target)
+        {
+            target.Clear();
+            foreach (var collection in trackItem.Keyframes.Values)
+            {
+                foreach (var keyframe in collection)
+                {
+                    target[keyframe] = keyframe.Frame;
+                }
+            }
+        }
+
+        private static void ApplyKeyframeFrames(TrackItem trackItem, Dictionary<Keyframe, int> frames)
+        {
+            if (frames.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var collection in trackItem.Keyframes.Values)
+            {
+                foreach (var keyframe in collection)
+                {
+                    if (frames.TryGetValue(keyframe, out int frame))
+                    {
+                        keyframe.Frame = frame;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- make keyframe models observable and track their selection state to drive UI updates
- move clip keyframes in sync with drag operations and persist the offsets in undo data
- update track item keyframe interactions to support bidirectional dragging, selection toggling, and highlight styles

## Testing
- `dotnet build PressPlay.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5637da5883219f33cab2298ee3c1