### PR TITLE
Fix keyframe drag offset

### DIFF
--- a/PressPlay/Timeline/TrackItemControl.xaml.cs
+++ b/PressPlay/Timeline/TrackItemControl.xaml.cs
@@ -24,6 +24,7 @@ namespace PressPlay.Timeline
         private bool _keyframeToggleOnClick;
         private bool _keyframeDragInitiated;
         private Point _keyframeMouseDownPoint;
+        private int _keyframeInitialFrame;
 
         public TrackItemControl()
         {
@@ -294,6 +295,7 @@ namespace PressPlay.Timeline
                 _draggingStrip = GetParentItemsControl(fe);
                 _keyframeDragInitiated = false;
                 _keyframeToggleOnClick = kf.IsSelected;
+                _keyframeInitialFrame = kf.Frame;
                 if (_draggingStrip != null)
                 {
                     _keyframeMouseDownPoint = e.GetPosition(_draggingStrip);
@@ -335,8 +337,9 @@ namespace PressPlay.Timeline
                 }
 
                 double pixelsPerFrame = Constants.GetPixelsPerFrame(project.TimelineZoom);
-                int relativeFrames = (int)Math.Round(position.X / pixelsPerFrame, MidpointRounding.AwayFromZero);
-                int frame = item.Position.TotalFrames + relativeFrames;
+                double deltaPixels = position.X - _keyframeMouseDownPoint.X;
+                int frameOffset = (int)Math.Round(deltaPixels / pixelsPerFrame, MidpointRounding.AwayFromZero);
+                int frame = _keyframeInitialFrame + frameOffset;
                 int clipStartFrame = item.Position.TotalFrames;
                 int clipEndFrame = clipStartFrame + item.Duration.TotalFrames;
                 frame = Math.Max(clipStartFrame, Math.Min(clipEndFrame, frame));
@@ -357,6 +360,7 @@ namespace PressPlay.Timeline
             _draggingStrip = null;
             _keyframeToggleOnClick = false;
             _keyframeDragInitiated = false;
+            _keyframeInitialFrame = 0;
         }
 
         private void Keyframe_MouseRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Summary
- capture the keyframe's initial frame when the drag starts
- update the drag logic to use the mouse delta so the frame does not jump forward
- reset the cached frame when the drag ends

## Testing
- `dotnet test PressPlay.sln` *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5b64340883219337b7beb43cc65f